### PR TITLE
Fixes font of the axis labels

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1693,8 +1693,7 @@
 
                 ctx.fillStyle = axis.options.color;
                 // Important: Don't use quotes around axis.font.family! Just around single 
-                // font names like 'Times New Roman' that have a space in it, or if it includes a 
-                // special character).
+                // font names like 'Times New Roman' that have a space or special character in it.
                 ctx.font = f.style + " " + f.variant + " " + f.weight + " " + f.size + "px " + f.family;
                 ctx.textAlign = "start";
                 // middle align the labels - top would be more


### PR DESCRIPTION
The font names in the axis css font property were quoted, which makes the browser to interpret a list of fonts as a single font name (does not work, of course). This change removes the quotes.
