### PR TITLE
Pie resize

### DIFF
--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -278,6 +278,7 @@ More detail and specific examples can be found in the included HTML file.
 			var slices = plot.getData();
 		
 			var attempts = 0;
+			redraw = true;
 			while (redraw && attempts<redrawAttempts)
 			{
 				redraw = false;


### PR DESCRIPTION
The pie plugin doesn't redraw after a resize occurs, even though the flot resize plugin triggers a redraw.
This is caused by the fact that the 'redraw' boolean in the pie plugin is set to 'false'.

This patch simply sets it to 'true' just before drawing, to ensure it is always redrawn in the draw() call.
