### PR TITLE
Allow a stroke of zero on pie slices

### DIFF
--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -372,13 +372,15 @@ More detail and specific examples can be found in the included HTML file.
 				ctx.restore();
 				
 				// draw slice outlines
-				ctx.save();
-				ctx.lineWidth = options.series.pie.stroke.width;
-				currentAngle = startAngle;
-				for (var i = 0; i < slices.length; ++i)
-					drawSlice(slices[i].angle, options.series.pie.stroke.color, false);
-				ctx.restore();
-					
+				if (options.series.pie.stroke.width > 0){
+					ctx.save();
+					ctx.lineWidth = options.series.pie.stroke.width;
+					currentAngle = startAngle;
+					for (var i = 0; i < slices.length; ++i)
+						drawSlice(slices[i].angle, options.series.pie.stroke.color, false);
+					ctx.restore();
+				}
+				
 				// draw donut hole
 				drawDonutHole(ctx);
 				


### PR DESCRIPTION
When you set the stroke to 1px, the stroke is 1px as it should be. But, when you set the stroke to 0, the stroke is still drawn as 1px. This fixes that bug.
