### PR TITLE
Added recoloring to pie charts which have had slices combined

### DIFF
--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -232,7 +232,7 @@ More detail and specific examples can be found in the included HTML file.
 			var combined = 0;
 			var numCombined = 0;
 			var color = options.series.pie.combine.color;
-		
+			var newcolor = 0;
 	
 			var newdata = [];
 			for (var i = 0; i < data.length; ++i)


### PR DESCRIPTION
If you had a pie chart with large number of data point and used the combine feature to combine the smaller slices it could result in an ugly graph as the original colors would be kept (the lower down colors tend to be less attractive and there's nothing to stop similar colours appearing next to each other post-combine). 

This patch adds a "recolor" boolean option to the combine feature whereby the colors get reassigned after the combine resulting in a more attractive pie chart.
