### PR TITLE
fix legend width bug

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2249,7 +2249,7 @@
             if (fragments.length == 0)
                 return;
 
-            var table = '<table style="font-size:smaller;color:' + options.grid.color + '">' + fragments.join("") + '</table>';
+            var table = '<table style="font-size:smaller;width:auto;color:' + options.grid.color + '">' + fragments.join("") + '</table>';
             if (options.legend.container != null)
                 $(options.legend.container).html(table);
             else {


### PR DESCRIPTION
The legend table was assuming that the default table width was set to auto without actually setting it to be so, which means that if you use a CSS framework like Twitter's Bootstrap which sets the default table width to 100% then you end up with the legend being stretched across the entire graph with no way to fix it.

Fixed by setting the legend table to auto.
