### PR TITLE
adds axis.option.maxFloor

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1120,6 +1120,10 @@
                     }
                 }
             }
+
+            if ( opts.maxFloor && max < opts.maxFloor ) 
+              max = opts.maxFloor;
+
             axis.min = min;
             axis.max = max;
         }


### PR DESCRIPTION
Needed my graphs to be at least 5 units tall -- our graphs don't like dealing with floating points, and we didn't want to fully customize the tick-formatter or re-implement flot's axis-scaling code. 

This patch adds a minimum-value for axis size, maxFloor.  Don't know if the code needs to be cleaner, but seems to work for me.
