### PR TITLE
Navigate selections in flot selection plugin

### DIFF
--- a/jquery.flot.selection.js
+++ b/jquery.flot.selection.js
@@ -138,6 +138,7 @@ The plugin also adds the following methods to the plot object:
         // redraw
         selection.navigate = false;
         setSelectionPos(selection.first, e);
+        setSelectionPos(selection.second, e);
       }
 
       selection.active = true;


### PR DESCRIPTION
Added navigate option to flot selection plugin. If navigate is set to true, clicking inside a selection lets you move it around instead of making a new selection.
