### PR TITLE
Throw IE- and Safari-friendly error upon finding invalid dimensions.

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -713,7 +713,7 @@
             canvasHeight = placeholder.height();
             
             if (canvasWidth <= 0 || canvasHeight <= 0)
-                throw "Invalid dimensions for plot, width = " + canvasWidth + ", height = " + canvasHeight;
+                throw new Error("Invalid dimensions for plot, width = " + canvasWidth + ", height = " + canvasHeight);
         }
 
         function resizeCanvas(c) {


### PR DESCRIPTION
As [Nicholas Zakas explains](http://www.nczonline.net/blog/2009/03/10/the-art-of-throwing-javascript-errors-part-2/), old versions of IE and Safari show less-than-meaningful messages ("Exception thrown and not caught on line X") when strings are thrown instead of instances of the Error object. This commit addresses this issue.
