### PR TITLE
allow the legend label formatter to omit labels by returning null

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2222,7 +2222,7 @@
                 return;
             
             var fragments = [], rowStarted = false,
-                lf = options.legend.labelFormatter, s, label;
+                lf = options.legend.labelFormatter, s, label, legendEntryCount = 0;
             for (var i = 0; i < series.length; ++i) {
                 s = series[i];
                 label = s.label;
@@ -2235,7 +2235,7 @@
                 if (!label)
                     continue;
 
-                if (i % options.legend.noColumns == 0) {
+                if (legendEntryCount % options.legend.noColumns == 0) {
                     if (rowStarted)
                         fragments.push('</tr>');
                     fragments.push('<tr>');
@@ -2245,6 +2245,8 @@
                 fragments.push(
                     '<td class="legendColorBox"><div style="border:1px solid ' + options.legend.labelBoxBorderColor + ';padding:1px"><div style="width:4px;height:0;border:5px solid ' + s.color + ';overflow:hidden"></div></div></td>' +
                     '<td class="legendLabel">' + label + '</td>');
+
+                legendEntryCount++;
             }
             if (rowStarted)
                 fragments.push('</tr>');


### PR DESCRIPTION
in my graph i had multiple series being grouped by color according to some caregory and the legend should only show what color represents what category while the tooltips should work with the individual labels.
