### PR TITLE
triggerClickHoverEvent should pass the original event through

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2432,7 +2432,11 @@
                     highlight(item.series, item.datapoint, eventname);
             }
             
-            placeholder.trigger(eventname, [ pos, item ]);
+            event.type = eventname;
+            
+            // The jQuery docs do not say that you can pass an event and extraParameters, but the source code shows
+            // that extra parameters are passed regardless of whether a string or jQuery Event is passed in.
+            placeholder.trigger(event, [ pos, item ]);
         }
 
         function triggerRedrawOverlay() {


### PR DESCRIPTION
There currently is no way to get information about whether the shift, meta or command keys were pressed when a `plotclick` event is triggered. This is because the original event object is not used when triggering the new event.

The `triggerClickHoverEvent` function triggers a new event by calling `jQuery.trigger()` with a string (e.g. 'plotclick') instead of the event object. Because the original event is not being used, we lose all information about the event (eg. which modifier keys were pressed).

This patch uses the original event object but replaces the TYPE attribute with the new event name.

```
event.type = eventname;
placeholder.trigger(event, [ pos, item ]);
```
