### PR TITLE
Expose Plot.findNearbyItem method

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -186,6 +186,7 @@
         };
         plot.getXAxes = function () { return xaxes; };
         plot.getYAxes = function () { return yaxes; };
+        plot.findNearbyItem = findNearbyItem;
         plot.c2p = canvasToAxisCoords;
         plot.p2c = axisToCanvasCoords;
         plot.getOptions = function () { return options; };


### PR DESCRIPTION
- Allows detection of items outside of the `plothover` event.

I ran into a need to locate the point closest to a position, and noticed that the logic was already fully implemented, but not exposed as a public method. I couldn't find a good reason for `findNearbyItem` to remain private, so this commit exposes it as a public method.
