### PR TITLE
navigate plugin: don't just give up if new zoom is outside the zoomRange...

### DIFF
--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -249,10 +249,32 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
                 }
 
                 var range = max - min;
-                if (zr &&
-                    ((zr[0] != null && range < zr[0]) ||
-                     (zr[1] != null && range > zr[1])))
-                    return;
+                if (zr)
+                {
+                    // Note these calculations are done in point-space, not canvas-space, so the center
+                    // may not be quite right when using a nonlinear transform function. The zoomRange is defined
+                    // in point-space coordinates and from what I can tell, getting the center right for an arbitrary
+                    // transform function would require some sort of numerical method. Which is overkill for a
+                    // corner case like this.
+                    // In fact, the "center" we take is the existing view's center. This stops users at maximum zoom
+                    // being able to "crawl" along the axis in a strange way.
+                    if (zr[0] != null && range < zr[0])
+                    {
+                        // so we'll choose a new max & min whose range will equal the min possible zoomRange
+                        var center = ( opts.min + opts.max ) / 2.0;
+			min = center - ( zr[0] / 2.0 );
+			max = min + zr[0];
+			range = zr[0];
+                    }
+                    if (zr[1] != null && range > zr[1])
+                    {
+                        // so we'll choose a new max & min whose range will equal the max possible zoomRange
+                        var center = ( opts.min + opts.max ) / 2.0;
+			min = center - ( zr[1] / 2.0 );
+			max = min + zr[1];
+			range = zr[1];
+                    }
+                }
             
                 opts.min = min;
                 opts.max = max;


### PR DESCRIPTION
Hi,

A bit of a stranger patch here. Do with as you like. Instead of giving up if the new zoom is outside the zoomRange, choose a new viewport whose range is the min/max range. This is useful if the plot's zoom is also being manipulated by other means and so would end up in a state "between zoom steps". This would mean you would get to a point where you could never zoom "fully out" as that final step would take you beyond the zoom range.

Note the issues around choosing the centerpoint of the new viewport documented in the source.
