### PR TITLE
Navigation plugin: unify panRange & zoomRange restriction handling

### DIFF
--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -12,6 +12,7 @@ Options:
   zoom: {
     interactive: false
     trigger: "dblclick" // or "click" for single click
+    mousewheel: true, // whether mousewheel events should be caught for zooming
     amount: 1.5         // 2 = 200% (zoom in), 0.5 = 50% (zoom out)
   }
   
@@ -127,6 +128,7 @@ arguments)};var o=h.fixHooks.touchstart=h.fixHooks.touchmove=h.fixHooks.touchend
         zoom: {
             interactive: false,
             trigger: "dblclick", // or "click" for single click
+            mousewheel: true, // whether mousewheel events should be caught for zooming
             amount: 1.5 // how much to zoom relative to current position, 2 = 200% (zoom in), 0.5 = 50% (zoom out)
         },
         pan: {
@@ -214,7 +216,8 @@ arguments)};var o=h.fixHooks.touchstart=h.fixHooks.touchmove=h.fixHooks.touchend
             var o = plot.getOptions();
             if (o.zoom.interactive) {
                 eventHolder[o.zoom.trigger](onZoomClick);
-                eventHolder.mousewheel(onMouseWheel);
+                if (o.zoom.mousewheel)
+                    eventHolder.mousewheel(onMouseWheel);
             }
 
             if (o.pan.interactive) {


### PR DESCRIPTION
Hi,

This is supposed to supersede my pull requests 44 & 45, which I'll close.

I've merged those two branches into something that uses a single setMinMax method to sanitize & set the min/max of an axis.

I've also added a setRanges & getRanges set of methods I needed that are supposed to mirror the behaviour of setSelection et al in the selection plugin.

On top of that I've updated the included jquery.event.drag for better jquery 1.7 support and partial touch event support.

You probably won't want all these changes, so I'm afraid you might just have to do some cherrypicking of patches, as I've already got more than enough branches to worry about :)
