### PR TITLE
time plugin: add support for quarters

### DIFF
--- a/jquery.flot.time.js
+++ b/jquery.flot.time.js
@@ -56,6 +56,8 @@ for details.
                 case 'l': c = leftPad(hours12, " "); break;
                 case 'm': c = leftPad(d.getMonth() + 1); break;
                 case 'M': c = leftPad(d.getMinutes()); break;
+                // quarters not in Open Group's strftime specification
+                case 'q': c = "Q" + (Math.floor(d.getMonth()/3) + 1); break;
                 case 'S': c = leftPad(d.getSeconds()); break;
                 case 'y': c = leftPad(d.getFullYear() % 100); break;
                 case 'Y': c = "" + d.getFullYear(); break;
@@ -129,12 +131,13 @@ for details.
         "hour": 60 * 60 * 1000,
         "day": 24 * 60 * 60 * 1000,
         "month": 30 * 24 * 60 * 60 * 1000,
+        "quarter": 3 * 30 * 24 * 60 * 60 * 1000,
         "year": 365.2425 * 24 * 60 * 60 * 1000
     };
 
     // the allowed tick sizes, after 1 year we use
     // an integer algorithm
-    var spec = [
+    var base_spec = [
         [1, "second"], [2, "second"], [5, "second"], [10, "second"],
         [30, "second"], 
         [1, "minute"], [2, "minute"], [5, "minute"], [10, "minute"],
@@ -143,9 +146,11 @@ for details.
         [8, "hour"], [12, "hour"],
         [1, "day"], [2, "day"], [3, "day"],
         [0.25, "month"], [0.5, "month"], [1, "month"],
-        [2, "month"], [3, "month"], [6, "month"],
-        [1, "year"]
+        [2, "month"]
     ];
+    // we don't know which variant(s) we'll need yet, but generating both is cheap
+    var spec_months = base_spec.concat ( [ [3, "month"], [6, "month"], [1, "year"] ] );
+    var spec_quarters = base_spec.concat ( [ [1, "quarter"], [2, "quarter"], [1, "year"] ] );
 
     function init(plot) {
         plot.hooks.processDatapoints.push(function (plot, series, datapoints) {
@@ -155,7 +160,10 @@ for details.
                     axis.tickGenerator = function(axis) {
                         var ticks = [],
                             d = dateGenerator(axis.min, opts),
-                            minSize = 0;
+                            minSize = 0,
+                            // make quarter use a possibility if quarters are mentioned in either of these options
+                            spec = (opts.tickSize && opts.tickSize[1] === "quarter") ||
+                                (opts.minTickSize && opts.minTickSize[1] === "quarter") ? spec_quarters : spec_months;
 
                         if (opts.minTickSize != null) {
                             if (typeof opts.tickSize == "number")
@@ -212,6 +220,8 @@ for details.
                             d.setHours(floorInBase(d.getHours(), tickSize));
                         if (unit == "month")
                             d.setMonth(floorInBase(d.getMonth(), tickSize));
+                        if (unit == "quarter")
+                            d.setMonth(3*floorInBase(d.getMonth()/3, tickSize));
                         if (unit == "year")
                             d.setFullYear(floorInBase(d.getFullYear(), tickSize));
                         
@@ -225,6 +235,10 @@ for details.
                             d.setHours(0);
                         if (step >= timeUnitSize.day * 4)
                             d.setDate(1);
+                        if (step >= timeUnitSize.month * 2)
+                            d.setMonth(floorInBase(d.getMonth(), 3));
+                        if (step >= timeUnitSize.quarter * 2)
+                            d.setMonth(floorInBase(d.getMonth(), 6));
                         if (step >= timeUnitSize.year)
                             d.setMonth(0);
 
@@ -234,21 +248,21 @@ for details.
                             prev = v;
                             v = d.getTime();
                             ticks.push(v);
-                            if (unit == "month") {
+                            if (unit == "month" || unit == "quarter") {
                                 if (tickSize < 1) {
-                                    // a bit complicated - we'll divide the month
+                                    // a bit complicated - we'll divide the month/quarter
                                     // up but we need to take care of fractions
                                     // so we don't end up in the middle of a day
                                     d.setDate(1);
                                     var start = d.getTime();
-                                    d.setMonth(d.getMonth() + 1);
+                                    d.setMonth(d.getMonth() + (unit == "quarter" ? 3 : 1));
                                     var end = d.getTime();
                                     d.setTime(v + carry * timeUnitSize.hour + (end - start) * tickSize);
                                     carry = d.getHours();
                                     d.setHours(0);
                                 }
                                 else
-                                    d.setMonth(d.getMonth() + tickSize);
+                                    d.setMonth(d.getMonth() + tickSize*(unit == "quarter" ? 3 : 1));
                             }
                             else if (unit == "year") {
                                 d.setFullYear(d.getFullYear() + tickSize);
@@ -260,14 +274,22 @@ for details.
                         return ticks;
                     };
 
-                    axis.tickFormatter = function (v, axis) {
+                    axis.tickFormatter = function (v, axis, tickSize) {
                         var d = dateGenerator(v, axis.options);
+
+                        // possibly use quarters if quarters are mentioned in any of these places
+                        var use_quarters = ( tickSize && tickSize[1] == "quarter" ) ||
+                            ( axis.options.tickSize && axis.options.tickSize[1] == "quarter" ) ||
+                            ( axis.options.minTickSize && axis.options.minTickSize[1] == "quarter" );
+
+                        // allow tickSize argument to override tickSize used
+                        tickSize = tickSize || axis.tickSize;
 
                         // first check global format
                         if (opts.timeformat != null)
                             return formatDate(d, opts.timeformat, opts.monthNames, opts.dayNames);
                         
-                        var t = axis.tickSize[0] * timeUnitSize[axis.tickSize[1]];
+                        var t = tickSize[0] * timeUnitSize[tickSize[1]];
                         var span = axis.max - axis.min;
                         var suffix = (opts.twelveHourClock) ? " %p" : "";
                         var hourCode = (opts.twelveHourClock) ? "%I" : "%H";
@@ -282,11 +304,18 @@ for details.
                         }
                         else if (t < timeUnitSize.month)
                             fmt = "%b %d";
-                        else if (t < timeUnitSize.year) {
+                        else if ( (use_quarters && t < timeUnitSize.quarter) ||
+                                (!use_quarters && t < timeUnitSize.year) ) {
                             if (span < timeUnitSize.year)
                                 fmt = "%b";
                             else
                                 fmt = "%b %Y";
+                        }
+                        else if (use_quarters && t < timeUnitSize.year) {
+                            if (span < timeUnitSize.year)
+                                fmt = "%q";
+                            else
+                                fmt = "%q %Y";
                         }
                         else
                             fmt = "%Y";


### PR DESCRIPTION
Hi there,

The first patch here is a more or less straightforward implementation of quarters support for time tick generation & labelling. People in the business world like quarters for some reason.

To do this I've had to add a letter for quarters in formatDate. Open Group strftime doesn't have one, so I had to make one up. "q". Hope that's ok.

At the moment it's a possibly little over-keen on using quarters, and I don't know how much "ordinary people" will appreciate that. I think it's roughly right for business users. One solution might be a configuration option to switch the use of quarters.

The second two patches implement a bit of a pet feature of mine. When I'm generating my tooltip text I introspect into the options and re-use the tickFormatter function to present a value. The first patch allows a caller to override the tickSize used and the second patch alters flot's tickFormatter wrapper function to pass thru arguments generically using arguments and apply to allow any extra arguments to be passed through to the original function unscathed.

Use what you like.
