### PR TITLE
Throw error when flot.time plugin is missing.

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1222,9 +1222,9 @@
                     return v.toFixed(axis.tickDecimals);
                 };
             }
-	    else if (opts.mode === "time" && typeof axis.tickGenerator === "undefined") {
+            else if (opts.mode == "time" && axis.tickGenerator == undefined) {
                 throw new Error("Time mode requires the flot.time plugin.");
-	    }
+            }
 
             if ($.isFunction(opts.tickFormatter))
                 axis.tickFormatter = function (v, axis) { return "" + opts.tickFormatter(v, axis); };


### PR DESCRIPTION
Fixes issue 709 on google code.
