### PR TITLE
Patch for Issue 716

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1577,7 +1577,7 @@
                 
                 for (var i = 0; i < axis.ticks.length; ++i) {
                     var tick = axis.ticks[i];
-                    if (!tick.label || tick.v < axis.min || tick.v > axis.max)
+                    if (!tick.label || tick.v > axis.max)
                         continue;
 
                     var x, y, offset = 0, line;

--- a/jquery.flot.time.js
+++ b/jquery.flot.time.js
@@ -222,7 +222,7 @@ for details.
                         if (step >= timeUnitSize.hour)
                             d.setMinutes(0);
                         if (step >= timeUnitSize.day)
-                            d.setHours(0);
+                            d.setHours(d.date.getTimezoneOffset()/60);
                         if (step >= timeUnitSize.day * 4)
                             d.setDate(1);
                         if (step >= timeUnitSize.year)


### PR DESCRIPTION
- Fixes the issue of the first tick label not displaying when time is on the X-axis 
- Previously UTC hours was set to 0 without taking timezone into account. This patch takes timezone offset into account to reset hours to 0.
- In some cases, the resetting of the first tick value forced it to be less than the minimum data value which resulted in the first tick label not being displayed. This patch always displays the first tick label whether the first tick value is less than or greater than axis.min. 
