### PR TITLE
Patch for Issue 699 and 628

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -518,7 +518,7 @@
             for (i = 0; i < series.length; ++i) {
                 s = series[i];
                 s.datapoints = { points: [] };
-                
+                s.extrapoints = [];
                 executeHooks(hooks.processRawData, [ s, s.data, s.datapoints ]);
             }
             
@@ -629,7 +629,7 @@
             for (i = 0; i < series.length; ++i) {
                 s = series[i];
                 
-                executeHooks(hooks.processDatapoints, [ s, s.datapoints]);
+                executeHooks(hooks.processDatapoints, [ s, s.datapoints, s.extrapoints]);
             }
 
             // second pass: find datamax/datamin for auto-scaling
@@ -1885,29 +1885,40 @@
             ctx.restore();
         }
 
+	function arrayContains(array, obj) {
+	        var i = array.length;
+	        while (i--) {
+	                if (array[i] == obj) {
+		              return true;
+                        }
+	        }
+	        return false;
+        }
+
+
         function drawSeriesPoints(series) {
             function plotPoints(datapoints, radius, fillStyle, offset, shadow, axisx, axisy, symbol) {
                 var points = datapoints.points, ps = datapoints.pointsize;
-
+		var extraPoints = series.extrapoints || [];
                 for (var i = 0; i < points.length; i += ps) {
-                    var x = points[i], y = points[i + 1];
-                    if (x == null || x < axisx.min || x > axisx.max || y < axisy.min || y > axisy.max)
-                        continue;
-                    
-                    ctx.beginPath();
-                    x = axisx.p2c(x);
-                    y = axisy.p2c(y) + offset;
-                    if (symbol == "circle")
-                        ctx.arc(x, y, radius, 0, shadow ? Math.PI : Math.PI * 2, false);
-                    else
-                        symbol(ctx, x, y, radius, shadow);
-                    ctx.closePath();
-                    
-                    if (fillStyle) {
-                        ctx.fillStyle = fillStyle;
-                        ctx.fill();
-                    }
-                    ctx.stroke();
+			if (!arrayContains(extraPoints,points[i])){
+	                    var x = points[i], y = points[i + 1];
+	                    if (x == null || x < axisx.min || x > axisx.max || y < axisy.min || y > axisy.max)
+	                        continue;
+	                    ctx.beginPath();
+	                    x = axisx.p2c(x);
+	                    y = axisy.p2c(y) + offset;
+	                    if (symbol == "circle")
+	                        ctx.arc(x, y, radius, 0, shadow ? Math.PI : Math.PI * 2, false);
+	                    else
+	                        symbol(ctx, x, y, radius, shadow);
+	                    ctx.closePath();
+	                    if (fillStyle) {
+	                        ctx.fillStyle = fillStyle;
+	                        ctx.fill();
+	                    }
+	                    ctx.stroke();
+	                }
                 }
             }
             

--- a/jquery.flot.stack.js
+++ b/jquery.flot.stack.js
@@ -50,7 +50,7 @@ adjusted (e.g for bar charts or filled areas).
             return res;
         }
         
-        function stackData(plot, s, datapoints) {
+        function stackData(plot, s, datapoints, extraPoints) {
             if (s.stack == null)
                 return;
 
@@ -124,6 +124,7 @@ adjusted (e.g for bar charts or filled areas).
                         if (withlines && i > 0 && points[i - ps] != null) {
                             intery = py + (points[i - ps + accumulateOffset] - py) * (qx - px) / (points[i - ps + keyOffset] - px);
                             newpoints.push(qx);
+                            extraPoints.push(qx);
                             newpoints.push(intery + qy);
                             for (m = 2; m < ps; ++m)
                                 newpoints.push(points[i + m]);
@@ -168,7 +169,7 @@ adjusted (e.g for bar charts or filled areas).
                     newpoints[l + 1] = newpoints[l - ps + 1];
                 }
             }
-
+			s.extrapoints = extraPoints;
             datapoints.points = newpoints;
         }
         


### PR DESCRIPTION
- Fixes the issue where extra (interpolated) points generated get displayed while drawing line stacks / lines with steps stacks
- Interpolated extra points are recognized and stored while series data is set
- When series points are drawn, the interpolated points that are not part of the actual data are skipped

Link to Issue 699: http://code.google.com/p/flot/issues/detail?id=699
Link to issue 628: http://code.google.com/p/flot/issues/detail?id=628
