### PR TITLE
Issue 494 bar overlap

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -107,7 +107,7 @@
                     },
                     bars: {
                         show: false,
-                        lineWidth: 2, // in pixels
+                        lineWidth: 1, // in pixels
                         barWidth: 1, // in units of the x axis
                         fill: true,
                         fillColor: null,


### PR DESCRIPTION
Problem was that bar outlines overlapped over gridlines; a suggestion was made to just change the line-width to be smaller. I halved the line-width of bars from 2 to 1 pixel.
