### PR TITLE
plotLineArea: fill path as one

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1719,6 +1719,7 @@
                     i = 0, top, areaOpen = false,
                     ypos = 1, segmentStart = 0, segmentEnd = 0;
 
+                ctx.beginPath();
                 // we process each segment in two turns, first forward
                 // direction to sketch out top, then once we hit the
                 // end we go backwards to sketch the bottom


### PR DESCRIPTION
I suppose this is more a rhetorical patch than anything.

Is there a reason plotLineArea() isn't done like so? Doing it like this allows me pull off a majorly useful hack in some of my other patches and follows the same way plotLine() does it.
