### PR TITLE
add setup/finishDrawContext and setup/finishDrawFillContext callback options to "lines" series options

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -105,7 +105,9 @@
                         fillColor: null,
                         steps: false,
                         setupDrawContext: null,
-                        setupDrawFillContext: null
+                        finishDrawContext: null,
+                        setupDrawFillContext: null,
+                        finishDrawFillContext: null
                     },
                     bars: {
                         show: false,
@@ -1879,22 +1881,26 @@
             var fillStyle = getFillStyle(series.lines, series.color, 0, plotHeight);
             if (fillStyle) {
                 ctx.fillStyle = fillStyle;
-                // push context on to the stack as we don't know what setupDrawFillContext
+                // push context on to the stack as we don't know what setupDrawFillContext & finishDrawFillContext
                 // will do to it (if anything)
                 ctx.save();
                 if ($.isFunction(series.lines.setupDrawFillContext))
                     series.lines.setupDrawFillContext(plot, series, ctx);
                 plotLineArea(series.datapoints, series.xaxis, series.yaxis);
+                if ($.isFunction(series.lines.finishDrawFillContext))
+                    series.lines.finishDrawFillContext(plot, series, ctx);
                 ctx.restore();
             }
 
             if (lw > 0) {
-                // push context on to the stack as we don't know what setupDrawContext
+                // push context on to the stack as we don't know what setupDrawContext & finishDrawContext
                 // will do to it (if anything)
                 ctx.save();
                 if ($.isFunction(series.lines.setupDrawContext))
                     series.lines.setupDrawContext(plot, series, ctx);
                 plotLine(series.datapoints, 0, 0, series.xaxis, series.yaxis);
+                if ($.isFunction(series.lines.finishDrawContext))
+                    series.lines.finishDrawContext(plot, series, ctx);
                 ctx.restore();
             }
             ctx.restore();


### PR DESCRIPTION
Ok, esoteric option time, but I needed it, so _shrug_.

This allows an advanced user to mess around with the canvas context used to draw the line or line area fill just before the drawing is done. More complex effects can be achieved this way.

Also add corresponding "finish" callbacks to allow user to perhaps piggy-back on any state set up by plotLine() etc.

You may be wondering why I didn't implement these as hooks. Hooks seem to really be intended for things that are "stackable", whereas callbacks messing around with the context are almost necessarily going to trample each other if you try and use more than one at once.
