### PR TITLE
Cast tick label to string prior to `replace` call

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -943,7 +943,7 @@
                 // accept various kinds of newlines, including HTML ones
                 // (you can actually split directly on regexps in Javascript,
                 // but IE is unfortunately broken)
-                var lines = t.label.replace(/<br ?\/?>|\r\n|\r/g, "\n").split("\n");
+                var lines = String(t.label).replace(/<br ?\/?>|\r\n|\r/g, "\n").split("\n");
                 for (var j = 0; j < lines.length; ++j) {
                     var line = { text: lines[j] },
                         m = ctx.measureText(line.text);


### PR DESCRIPTION
In the edge case that an actual integer, or other non-string, is passed as a label, it must be cast to String before `replace` can safely be called.
