### PR TITLE
Fix makeCanvas() for IE after Retina feature introduced in 179d2e1

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -737,6 +737,11 @@
             var c = document.createElement('canvas');
             c.className = cls;
 
+            if (!skipPositioning)
+                $(c).css({ position: 'absolute', left: 0, top: 0 });
+
+            $(c).appendTo(placeholder);
+
             if (!c.getContext) // excanvas hack
                 c = window.G_vmlCanvasManager.initElement(c);
 
@@ -753,11 +758,6 @@
             c.height = canvasHeight * pixelRatio;
             c.style.width = canvasWidth + "px";
             c.style.height = canvasHeight + "px";
-
-            if (!skipPositioning)
-                $(c).css({ position: 'absolute', left: 0, top: 0 });
-
-            $(c).appendTo(placeholder);
 
             // Save the context so we can reset in case we get replotted
 


### PR DESCRIPTION
Hi,

This patch gets makeCanvas() working again in IE8. I found it was broken since merge of the pull request #52 where olivierguerriat enhanced support for Retina display (commit 179d2e1). Though I have not tested much that patch, I can confirm it makes IE8 drawing back pies and does not seem to introduce new problems in FF 10.0.4 nor Chrome 18.0.1025.168.

Regards,
Julien
