### PR TITLE
Ability to customize tilted pie shadow

### DIFF
--- a/examples/pie.html
+++ b/examples/pie.html
@@ -671,6 +671,11 @@ $("#interactive").bind("plotclick", pieClick);</b><br/>
 		<li><b>innerRadius:</b> <i>0</i> - Sets the radius of the donut hole. If value is between 0 and 1 (inclusive) then it will use that as a percentage of the radius, otherwise it will use the value as a direct pixel length.</li>
 		<li><b>startAngle:</b> <i>3/2</i> - Factor of PI used for the starting angle (in radians) It can range between 0 and 2 (where 0 and 2 have the same result).</li>
 		<li><b>tilt:</b> <i>1</i> - Percentage of tilt ranging from 0 and 1, where 1 has no change (fully vertical) and 0 is completely flat (fully horizontal -- in which case nothing actually gets drawn).</li>
+		<li><b>shadow:</b> <ul>
+			<li><b>top:</b> <i>5</i> - Vertical distance in pixel of the tilted pie shadow.</li>
+			<li><b>left:</b> <i>15</i> - Horizontal distance in pixel of the tilted pie shadow.</li>
+			<li><b>alpha:</b> <i>0.02</i> - Alpha value of the tilted pie shadow.</li>
+		</ul>
 		<li><b>offset:</b> <ul>
 			<li><b>top:</b> <i>0</i> - Pixel distance to move the pie up and down (relative to the center).</li>
 			<li><b>left:</b> <i>'auto'</i> - Pixel distance to move the pie left and right (relative to the center).</li>

--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -310,10 +310,10 @@ More detail and specific examples can be found in the included HTML file.
 			
 			function drawShadow()
 			{
-				var shadowLeft = 5;
-				var shadowTop = 15;
+				var shadowLeft = options.series.pie.shadow.left;
+				var shadowTop = options.series.pie.shadow.top;
 				var edge = 10;
-				var alpha = 0.02;
+				var alpha = options.series.pie.shadow.alpha;
 			
 				// set radius
 				if (options.series.pie.radius>1)
@@ -712,6 +712,11 @@ More detail and specific examples can be found in the included HTML file.
 				innerRadius:0, /* for donut */
 				startAngle: 3/2,
 				tilt: 1,
+				shadow: {
+					left: 5,     // shadow left offset
+					top: 15,     // shadow top offset
+					alpha: 0.02, // shadow alpha
+				},
 				offset: {
 					top: 0,
 					left: 'auto'


### PR DESCRIPTION
Hi, 

This patch provides ability to customize top/left offset and alpha level of tilted Pie shadow. I have updated the documentation (pie example). Following is how to use it :

``` javascript
$.plot(
    $('#overall-state-summary div.pie-state'),
    state, 
    {    series: {
            pie: {
                show: true,
                startAngle: 4/9,
                radius: 3/4,
                innerRadius: 0.27,
                tilt: 0.5,
                shadow: {
                    left: 1,
                    top: 12,
                    alpha: 0.1,
                },
                offset: {
                    top: -5
                },
                stroke: {
                    color: '#585858',
                    width: 1
                },
                label: {
                    show: false,
                }
            }
        },
        legend: {
            show: false, 
        }
    }
);
```

Regards,
Julien
