### PR TITLE
Removed implicit global variables in threshold plugin

### DIFF
--- a/jquery.flot.threshold.js
+++ b/jquery.flot.threshold.js
@@ -56,8 +56,9 @@ events.
             var origpoints = datapoints.points,
                 addCrossingPoints = s.lines.show;
 
-            threspoints = [];
-            newpoints = [];
+            var threspoints = [];
+            var newpoints = [];
+            var m;
 
             for (i = 0; i < origpoints.length; i += ps) {
                 x = origpoints[i]


### PR DESCRIPTION
Three variables were implicit declered global. Changed to local variables.
