### PR TITLE
Added eventOnPanEnd to navigate extension

### DIFF
--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -18,11 +18,7 @@ Options:
   pan: {
     interactive: false
     cursor: "move"      // CSS mouse cursor value used when dragging, e.g. "pointer"
-    frameRate: 20,
-	eventOnPanEnd: function (plot)
-	{
-        Whatever you want your function to do.
-    }
+    frameRate: 20
   }
 
   xaxis, yaxis, x2axis, y2axis: {
@@ -125,8 +121,7 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
         pan: {
             interactive: false,
             cursor: "move",
-            frameRate: 20,
-            eventOnPanEnd: null
+            frameRate: 20
         }
     };
 
@@ -184,9 +179,6 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
             plot.getPlaceholder().css('cursor', prevCursor);
             plot.pan({ left: prevPageX - e.pageX,
                        top: prevPageY - e.pageY });
-            if (plot.getOptions().pan.eventOnPanEnd) {
-                plot.getOptions().pan.eventOnPanEnd(plot);
-            }
         }
         
         function bindEvents(plot, eventHolder) {

--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -18,7 +18,11 @@ Options:
   pan: {
     interactive: false
     cursor: "move"      // CSS mouse cursor value used when dragging, e.g. "pointer"
-    frameRate: 20
+    frameRate: 20,
+	eventOnPanEnd: function (plot)
+	{
+        Whatever you want your function to do.
+    }
   }
 
   xaxis, yaxis, x2axis, y2axis: {
@@ -121,7 +125,8 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
         pan: {
             interactive: false,
             cursor: "move",
-            frameRate: 20
+            frameRate: 20,
+            eventOnPanEnd: null
         }
     };
 
@@ -179,6 +184,9 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
             plot.getPlaceholder().css('cursor', prevCursor);
             plot.pan({ left: prevPageX - e.pageX,
                        top: prevPageY - e.pageY });
+            if (plot.getOptions().pan.eventOnPanEnd) {
+                plot.getOptions().pan.eventOnPanEnd(plot);
+            }
         }
         
         function bindEvents(plot, eventHolder) {

--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -121,8 +121,7 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
         pan: {
             interactive: false,
             cursor: "move",
-            frameRate: 20,
-			eventOnPanEnd: null
+            frameRate: 20
         }
     };
 
@@ -180,10 +179,6 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
             plot.getPlaceholder().css('cursor', prevCursor);
             plot.pan({ left: prevPageX - e.pageX,
                        top: prevPageY - e.pageY });
-            if (plot.getOptions().pan.eventOnPanEnd)
-			{
-            	plot.getOptions().pan.eventOnPanEnd(plot);
-            }
         }
         
         function bindEvents(plot, eventHolder) {

--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -18,7 +18,11 @@ Options:
   pan: {
     interactive: false
     cursor: "move"      // CSS mouse cursor value used when dragging, e.g. "pointer"
-    frameRate: 20
+    frameRate: 20,
+	eventOnPanEnd: function (plot)
+	{
+        Whatever you want your function to do.
+    }
   }
 
   xaxis, yaxis, x2axis, y2axis: {
@@ -121,7 +125,8 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
         pan: {
             interactive: false,
             cursor: "move",
-            frameRate: 20
+            frameRate: 20,
+            eventOnPanEnd: null
         }
     };
 
@@ -193,6 +198,9 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
                 eventHolder.bind("drag", onDrag);
                 eventHolder.bind("dragend", onDragEnd);
             }
+            if (plot.getOptions().pan.eventOnPanEnd) {
+                plot.getOptions().pan.eventOnPanEnd(plot);
+            } 
         }
 
         plot.zoomOut = function (args) {

--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -121,7 +121,8 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
         pan: {
             interactive: false,
             cursor: "move",
-            frameRate: 20
+            frameRate: 20,
+			eventOnPanEnd: null
         }
     };
 
@@ -179,6 +180,10 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
             plot.getPlaceholder().css('cursor', prevCursor);
             plot.pan({ left: prevPageX - e.pageX,
                        top: prevPageY - e.pageY });
+            if (plot.getOptions().pan.eventOnPanEnd)
+			{
+            	plot.getOptions().pan.eventOnPanEnd(plot);
+            }
         }
         
         function bindEvents(plot, eventHolder) {


### PR DESCRIPTION
The navigate functionality captures all mouse click events. Whilst the
extension has an onDragEnd event, this is not communicated to the
outside world. This commit adds eventOnPanEnd to the pan options,
enabling the calling code to pass a function through to the navigate
extension.

An example use case for this is wanting to make an Ajax call to retrieve
more data when the user has panned a graph. Binding to the plotPan event
is not useful in this case, as this fires every time the graph is moved.
I wanted to bind to the onMouseUp event, but the navigate extension
captures this event.
