### PR TITLE
Return null if we aren't showing a selection when calling getSelection.

### DIFF
--- a/jquery.flot.selection.js
+++ b/jquery.flot.selection.js
@@ -146,6 +146,8 @@ The plugin allso adds the following methods to the plot object:
         function getSelection() {
             if (!selectionIsSane())
                 return null;
+            
+            if (!selection.show) return null;
 
             var r = {}, c1 = selection.first, c2 = selection.second;
             $.each(plot.getAxes(), function (name, axis) {


### PR DESCRIPTION
If we've called `clearSelection`, then calling `getSelection` shouldn't
return the old selection values. When calling `getSelection` before a
selection is made, `null` is returned. It seemed appropriate to do the
same if `selection.show` was falsy.

Signed-off-by: Nick Campbell nicholas.j.campbell@gmail.com
