### PR TITLE
Make it so turning on filling under a plot line does not force the axis.min to go to 0

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -654,7 +654,10 @@
                     if (points[j] == null)
                         continue;
 
-                    for (m = 0; m < ps; ++m) {
+                    var temp_ps = ps;
+                    if ( s.lines.fill)
+                        temp_ps = ps -1;
+                    for (m = 0; m < temp_ps; ++m) {
                         val = points[j + m];
                         f = format[m];
                         if (!f || val == fakeInfinity || val == -fakeInfinity)


### PR DESCRIPTION
Mainline flot currently has a behavior where when "fill" is turned on for a line chart, the axis.min is set to 0, so the fill goes to the "zero line" ... In my use case at least, this completely distorts the chart and seems like an odd default behavior. This small change makes it so this doesn't happen, axis min/max is not affected by whether fill is on or off.

Note: This is not actually my patch, it is copied from comment on an issue filed in the old flot Google Code repo. Since it is no longer available, I can't give proper credit.
