### PR TITLE
Add "reversed" option to legend

### DIFF
--- a/API.md
+++ b/API.md
@@ -157,6 +157,7 @@ legend: {
     backgroundOpacity: number between 0 and 1
     container: null or jQuery object/DOM element/jQuery expression
     sorted: null/false, true, "ascending", "descending" or a comparator
+    reversed: boolean
 }
 ```
 
@@ -203,6 +204,9 @@ sorted: function(a, b) {
     )
 }
 ```
+
+Legend entries can be shown in reverse order if "reversed" is set to
+true. This can be useful for stacked plots.
 
 
 ## Customizing the axes ##

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -52,7 +52,8 @@
                     margin: 5, // distance from grid edge to default legend container within plot
                     backgroundColor: null, // null means auto-detect
                     backgroundOpacity: 0.85, // set to 0 to avoid background
-                    sorted: null    // default to no legend sorting
+                    sorted: null,    // default to no legend sorting
+                    reversed: null   // default to not reversed order
                 },
                 xaxis: {
                     show: null, // null = auto-detect, true = always, false = never
@@ -2245,6 +2246,12 @@
                         );
                     });
                 }
+            }
+
+            // Reverse the legend if needed
+
+            if (options.legend.reversed) {
+                entries.reverse();
             }
 
             // Generate markup for the list of entries, in their final order


### PR DESCRIPTION
Adds ability to draw legend in reverse order. For stacked & filled line charts, the default legend order produces "opposite" order from the natural one.
