### PR TITLE
Change evaluation order for calculating percentage

### DIFF
--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -267,7 +267,7 @@ More detail and specific examples can be found in the included HTML file.
 						color: data[i].color,
 						label: data[i].label,
 						angle: data[i].data[0][1] * Math.PI * 2 / total,
-						percent: data[i].data[0][1] / total * 100
+						percent: data[i].data[0][1] / (total / 100)
 					});
 				}
 			}
@@ -278,7 +278,7 @@ More detail and specific examples can be found in the included HTML file.
 					color: color,
 					label: options.series.pie.combine.label,
 					angle: combined * Math.PI * 2 / total,
-					percent: combined / total * 100
+					percent: combined / (total / 100)
 				});
 			}
 


### PR DESCRIPTION
Rounding errors are introduced when calculating the percentage when the total is 100 (for example if percentages have already been calculated). Calculating `total/100` first eliminates the error in this case.
