### PR TITLE
Support hoverable: true in jQuery v1.2.6

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -884,10 +884,12 @@ Licensed under the MIT license.
             // bind events
             if (options.grid.hoverable) {
                 eventHolder.mousemove(onMouseMove);
+
+                // Older versions of jQuery only support mouseout.
+
                 if (eventHolder.mouseleave) {
                     eventHolder.mouseleave(onMouseLeave);
-                }
-                else {
+                } else {
                     eventHolder.mouseout(onMouseLeave);
                 }
             }
@@ -904,6 +906,9 @@ Licensed under the MIT license.
 
             eventHolder.unbind("mousemove", onMouseMove);
             eventHolder.unbind("mouseleave", onMouseLeave);
+
+            // Older versions of jQuery only support mouseout.
+
             eventHolder.unbind("mouseout", onMouseLeave);
             eventHolder.unbind("click", onClick);
 


### PR DESCRIPTION
jQuery v1.2.6 does not support [`mouseleave`](http://api.jquery.com/mouseleave/).  However [`README.md`](http://daringfireball.net/projects/markdown/syntax#link) states v1.2.6 is supported, even for interactions (although jQuery v1.3.2 is recommended for performance reasons); _You need at least jQuery 1.2.6, but try at least 1.3.2 for interactive charts because of performance improvements in event handling._

This change prevents a fatal javascript error when using flot with `hoverable: true`.
