### PR TITLE
Add passing offsets over plotpan event

### DIFF
--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -319,7 +319,7 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
             plot.draw();
             
             if (!args.preventEvent)
-                plot.getPlaceholder().trigger("plotpan", [ plot ]);
+                plot.getPlaceholder().trigger("plotpan", [ plot, args ]);
         };
 
         function shutdown(plot, eventHolder) {


### PR DESCRIPTION
Unified this behavior with plotzoom event as in pull #34 (commit flot/flot@1b6c4e933ade3f03d634dfaa6357e82beda3bc55)

Again, synchronization of plots now can be done with:

``` javascript
onePlot.bind('plotpan', function (event, plot, args) {
    anotherPlot.pan(args);
});
```
