### PR TITLE
flot.threshold: insert generated series after original, not in the end

### DIFF
--- a/jquery.flot.threshold.js
+++ b/jquery.flot.threshold.js
@@ -103,8 +103,11 @@ You may need to check for this in hover events.
             datapoints.points = newpoints;
             thresholded.datapoints.points = threspoints;
             
-            if (thresholded.datapoints.points.length > 0)
-                plot.getData().push(thresholded);
+            if (thresholded.datapoints.points.length > 0) {
+                var origIndex = $.inArray(s, plot.getData());
+                // Insert newly-generated series right after original one (to prevent it from becoming top-most)
+                plot.getData().splice(origIndex + 1, 0, thresholded);
+            }
                 
             // FIXME: there are probably some edge cases left in bars
         }


### PR DESCRIPTION
Thus, prevent it from becoming topmost (it may cause strange looks if
original series is not topmost: some part of it becomes topmost and
overwrites some lines and points that should be above it instead).

This picture describes the issue the best:
![screen8](https://f.cloud.github.com/assets/26939/78091/70c5ec56-616e-11e2-870a-bbdc81a802fc.png)

It is generated in this jsFiddle: http://jsfiddle.net/nia_ru/z5YC6/
