### PR TITLE
Issue 688: Removing quotes from font definition.

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -961,7 +961,7 @@ Licensed under the MIT license.
                 f = axis.font;
 
             ctx.save();
-            ctx.font = f.style + " " + f.variant + " " + f.weight + " " + f.size + "px '" + f.family + "'";
+            ctx.font = f.style + " " + f.variant + " " + f.weight + " " + f.size + "px " + f.family;
 
             for (var i = 0; i < ticks.length; ++i) {
                 var t = ticks[i];


### PR DESCRIPTION
Hi,
I'm trying to contribute and picked a seemingly easy issue to tackle. The explicit quotes in the code were causing some fonts passed in with quotes around them to fail. As the issue mentions, it now matches the implementation in drawAxisLabels.

https://github.com/flot/flot/issues/688

Hope this helps.
Best regards!
