### PR TITLE
Adding a fix for the inability to set the point lineWidth to 0

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2092,6 +2092,15 @@ Licensed under the MIT license.
                 sw = series.shadowSize,
                 radius = series.points.radius,
                 symbol = series.points.symbol;
+
+            // If the user sets the line width to 0, we change it to a very 
+            // small value. A line width of 0 seems to force the default of 1.
+            // Doing the conditional here allows the shadow setting to still be 
+            // optional even with a lineWidth of 0.
+
+            if( lw == 0 )
+                lw = 0.0001;
+
             if (lw > 0 && sw > 0) {
                 // draw shadow in two steps
                 var w = sw / 2;


### PR DESCRIPTION
This is a bit of a hack taken from issue https://github.com/flot/flot/issues/842

One option is to set the point lineWidth very low as this patch does, and the other is to set the color to rgba(0,0,0,0). If the alpha option is used, then the point width is still technically set to 0, and the end result is that the shadows are lost. With the way this fix is implemented, the shadows can still be set to either 0 or a higher value.

Hope this is useful!
