### PR TITLE
Bug with default tickFormatter

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1326,7 +1326,7 @@ Licensed under the MIT license.
 
 				axis.tickFormatter = function (value, axis) {
 
-					var factor = Math.pow(10, axis.tickDecimals);
+					var factor = axis.tickDecimals ? Math.pow(10, axis.tickDecimals) : 1;
 					var formatted = "" + Math.round(value * factor) / factor;
 
 					// If tickDecimals was specified, ensure that we have exactly that


### PR DESCRIPTION
Ran into a bug with default axis.tickFormatter. If ticks are specified and axis.tickDecimals is not, ticks will be formatted to NaN.

This is because Math.pow(10, undefined) is NaN, whereas the code seems to be expecting axis.tickDecimals to be null when not set ( Math.pow(10, null) yields 1 ). So to fix the bug, if axis.tickDecimals is anything falsy (because Math.pow(10,0) is also 1), just use 1 as the factor.

Here is a minimal example of the bug:
http://sean.edisonjordan.com/code/flot/tickformatter-bug.html

Change-Id: If53fdb1bf9563834c58cf2b569d0e1a6a7155eb8
