### PR TITLE
Added option to control usage of devicePixelRatio and canvas scaling for "retina"-like displays

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -798,8 +798,9 @@ Licensed under the MIT license.
             // Scale the coordinate space to match the display density; so even though we
             // may have twice as many pixels, we still want lines and other drawing to
             // appear at the same size; the extra pixels will just make them crisper.
-
-            cctx.scale(pixelRatio, pixelRatio);
+            
+            if (pixelRatio != 1)
+                cctx.scale(pixelRatio, pixelRatio);
 
             return c;
         }
@@ -840,8 +841,8 @@ Licensed under the MIT license.
             cctx.save();
 
             // Apply scaling for retina displays, as explained in makeCanvas
-
-            cctx.scale(pixelRatio, pixelRatio);
+            if (pixelRatio != 1)
+                cctx.scale(pixelRatio, pixelRatio);
         }
 
         function setupCanvases() {


### PR DESCRIPTION
Retina display support was introduced in https://github.com/flot/flot/pull/52.
However, it seems that for large data sets and fast redraws (e.g. real-time) scaling a canvas may result in a performance hit. On my project I've got that iPad 2 was faster than iPad 4. Probably in such cases speed is more important than sharpness.

Here is sample: http://jsfiddle.net/p79gL/1/. On my HTC One X smartphone (devicePixelRation is 2) on native browser it shows about 11.5 fps.
While after disabling usage of devicePixelRatio (just make getPixelRatio() always return 1)  sample shows up to 20 fps performance. Sample is here: http://jsfiddle.net/p79gL/2/.
The same situation can be observed on other devices with "retina"-like displays (tested on iPad 4 and Google Nexus 7).

So in the pull request I suggest to introduce an option "useDevicePixelRatio" which is true by default. If it will be set to false, then devicePixelRatio won't be used and getPixelRation() function will return just 1. Also it doesn't make sense to scale canvas if pixelRatio is 1.
