### PR TITLE
Add plot object in plotHover callback, in order to access plot data

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2533,7 +2533,7 @@ Licensed under the MIT license.
                     highlight(item.series, item.datapoint, eventname);
             }
 
-            placeholder.trigger(eventname, [ pos, item ]);
+            placeholder.trigger(eventname, [ pos, item, plot ]);
         }
 
         function triggerRedrawOverlay() {


### PR DESCRIPTION
This is needed by curvedLine plugin which force to have 2 series (one to
display curve, and one to display real point). So label are to be read
on 1 series but event is thrown of the second series.

With this patch, we can access to previous series to get label, in order to display it in
plotHover div.
