### PR TITLE
Adding additional hook.

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2234,7 +2234,7 @@ Licensed under the MIT license.
                 c.stroke();
             }
 
-            executeHooks(hooks.barDrawn, [c, top, right, bottom, left]);
+            executeHooks(hooks.barDrawn, [c, top, right, bottom, left, offset]);
 
         }
 


### PR DESCRIPTION
I am writing a plugin that will make the charts accessible for people with different kinds of color blindness.

I need to draw patterns on-top of the series and the current hooks provided like "drawSeries" executes before the objects are drawn. This causes my patterns to be drawn behind a bar for example. This is why I need a hook for after draw. This way I can draw on-top of the chart.

I see various hooks that I would like to add but I don't know what is your policy on this?
In example: onBarDrawn with a signature that would contain all the coordinates of the bar.
