### PR TITLE
Expose executeHooks() publicly so plugins can add and trigger custom events.

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -583,6 +583,7 @@ Licensed under the MIT license.
         plot.highlight = highlight;
         plot.unhighlight = unhighlight;
         plot.triggerRedrawOverlay = triggerRedrawOverlay;
+        plot.executeHooks = executeHooks;
         plot.pointOffset = function(point) {
             return {
                 left: parseInt(xaxes[axisNumber(point, "x") - 1].p2c(+point.x) + plotOffset.left, 10),


### PR DESCRIPTION
I'd like to be able to call custom hooks from within my plugin. This would give users and other plugins the ability to listen and respond to my plugin-specific behavior.

What I can do alraedy:
I've added `plot.hooks.crosshairSnap = [];` to my plugin's `init()`.

What I can't do (yet):
Call `plot.executeHooks(plot.hooks.crosshairSnap, [axisX]);`.

This pull request adds `executeHooks` as a publicly-accessible method on `plot`.
