### PR TITLE
Allow defining highlightColor as a function

### DIFF
--- a/API.md
+++ b/API.md
@@ -85,7 +85,7 @@ The format of a single series object is as follows:
     clickable: boolean
     hoverable: boolean
     shadowSize: number
-    highlightColor: color or number
+    highlightColor: color string or a function
 }
 ```
 
@@ -713,7 +713,7 @@ series: {
     }
 
     shadowSize: number
-    highlightColor: color or number
+    highlightColor: color string or a function
 }
 
 colors: [ color1, color2, ... ]
@@ -803,7 +803,22 @@ ensures that all symbols have approximately the same visual weight.
 remove shadows.
 
 "highlightColor" is the default color of the translucent overlay used
-to highlight the series when the mouse hovers over it.
+to highlight the series when the mouse hovers over it. You can specify
+either a string or a function, that evaluates to a string for a given
+"series" and "datapoint":
+
+```js
+highlightColor: "#d18b2c"
+```
+
+or
+
+```js
+highlightColor: function (series, datapoint) {
+  return datapoint[0] < 5 ? "#f1493e" : "#ffce14";
+}
+```
+
 
 The "colors" array specifies a default color theme to get colors for
 the data series from. You can specify as many colors as you like, like

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2862,10 +2862,19 @@ Licensed under the MIT license.
             return -1;
         }
 
+        function getHighlightColor(series, point) {
+            if (typeof series.highlightColor === "string")
+                return series.highlightColor;
+            else if(typeof series.highlightColor === "function")
+                return series.highlightColor (series, point);
+            else
+                return $.color.parse(series.color).scale('a', 0.5).toString();
+        }
+
         function drawPointHighlight(series, point) {
             var x = point[0], y = point[1],
                 axisx = series.xaxis, axisy = series.yaxis,
-                highlightColor = (typeof series.highlightColor === "string") ? series.highlightColor : $.color.parse(series.color).scale('a', 0.5).toString();
+                highlightColor = getHighlightColor(series, point);
 
             if (x < axisx.min || x > axisx.max || y < axisy.min || y > axisy.max)
                 return;
@@ -2887,7 +2896,7 @@ Licensed under the MIT license.
         }
 
         function drawBarHighlight(series, point) {
-            var highlightColor = (typeof series.highlightColor === "string") ? series.highlightColor : $.color.parse(series.color).scale('a', 0.5).toString(),
+            var highlightColor = getHighlightColor(series, point),
                 fillStyle = highlightColor,
                 barLeft = series.bars.align == "left" ? 0 : -series.bars.barWidth/2;
 


### PR DESCRIPTION
Declaring the *highlightColor* as a function will provide more control over the color applied to each highlighted item.

 *highlightColor*, when defined as a function, is passed two parameters: series and datapoint and should return a color string. Example usage:

```javascript
highlightColor: function (series, datapoint) {
  return datapoint[0] < 5 ? "#f1493e" : "#ffce14";
}
```
