### PR TITLE
Proper dependency for jQuery component

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,6 +3,6 @@
 	"version": "0.8.0-beta",
 	"main": "jquery.flot.js",
 	"dependencies": {
-		"jquery": ">= 1.2.6"
+		"component/jquery": ">= 1.2.6"
 	}
 }


### PR DESCRIPTION
Assuming this component.json follows the conventions of https://github.com/component/component, the proper name for jQuery would be `component/jquery` (otherwise `component install flot/flot` fails with `invalid component name "jquery"`).
