### PR TITLE
Jshint changes

### DIFF
--- a/jquery.colorhelpers.js
+++ b/jquery.colorhelpers.js
@@ -29,7 +29,7 @@
         o.r = r || 0;
         o.g = g || 0;
         o.b = b || 0;
-        o.a = a !== null ? a : 1;
+        o.a = a != null ? a : 1;
 
         o.add = function (c, d) {
             for (var i = 0; i < c.length; ++i)


### PR DESCRIPTION
I saw the problem with flot not passing the travis-ci tests and started to work just a little bit on the problem. My first changes are in the jquery.colorhelpers.js file since that file is the first file that makes jshint angry. You would now only need to include the file in the jquery.flot.js file (like it is already done with the old version) and would get some errors less. What do you think?
