### PR TITLE
Allow custom stroke color for points

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -483,6 +483,7 @@ Licensed under the MIT license.
                         lineWidth: 2, // in pixels
                         fill: true,
                         fillColor: "#ffffff",
+                        strokeColor: null,
                         symbol: "circle" // or callback
                     },
                     lines: {
@@ -2357,7 +2358,7 @@ Licensed under the MIT license.
             }
 
             ctx.lineWidth = lw;
-            ctx.strokeStyle = series.color;
+            ctx.strokeStyle = series.points.strokeColor ? series.points.strokeColor : series.color;
             plotPoints(series.datapoints, radius,
                        getFillStyle(series.points, series.color), 0, false,
                        series.xaxis, series.yaxis, symbol);


### PR DESCRIPTION
Not sure if other shapes need this, but circles really do (especially when used with lines).

![Screen Shot 2013-03-22 at 1 13 18 PM](https://f.cloud.github.com/assets/223121/291900/e6ecb6ae-9313-11e2-96ac-d9033f985d1d.png)
