### PR TITLE
Remove some incorrect else-if logic in time plugin

### DIFF
--- a/jquery.flot.time.js
+++ b/jquery.flot.time.js
@@ -294,17 +294,23 @@ API.txt for details.
 
 						if (step >= timeUnitSize.minute) {
 							d.setSeconds(0);
-						} else if (step >= timeUnitSize.hour) {
+						}
+						if (step >= timeUnitSize.hour) {
 							d.setMinutes(0);
-						} else if (step >= timeUnitSize.day) {
+						}
+						if (step >= timeUnitSize.day) {
 							d.setHours(0);
-						} else if (step >= timeUnitSize.day * 4) {
+						}
+						if (step >= timeUnitSize.day * 4) {
 							d.setDate(1);
-						} else if (step >= timeUnitSize.month * 2) {
+						}
+						if (step >= timeUnitSize.month * 2) {
 							d.setMonth(floorInBase(d.getMonth(), 3));
-						} else if (step >= timeUnitSize.quarter * 2) {
+						}
+						if (step >= timeUnitSize.quarter * 2) {
 							d.setMonth(floorInBase(d.getMonth(), 6));
-						} else if (step >= timeUnitSize.year) {
+						}
+						if (step >= timeUnitSize.year) {
 							d.setMonth(0);
 						}
 


### PR DESCRIPTION
It looks like there was some incorrect else-if logic introduced in the time plugin @ f8064ca7ea4f3ff20516c0376d8c24841fdc7ec2

Before that commit, our chart looks this: http://d.pr/i/2YXq

Note the crosshair is just before the Feb month tick and the legend says Jan 31 - good.

After that commit, our chart looks like this: http://d.pr/i/lewG

Besides the fact that a new tick was added, the crosshair is again just before the Feb month tick but the legend says Feb 15 - so that's not right.

I corrected the offending change here and now it works again.

This may be related to #1017
