### PR TITLE
Regression on pie plugin in the data format allowed

### DIFF
--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -180,6 +180,10 @@ More detail and specific examples can be found in the included HTML file.
 				// new one; this is more efficient and preserves any extra data
 				// that the user may have stored in higher indexes.
 
+				if ($.isArray(value) && value.length == 1) {
+    				value = value[0];
+				}
+
 				if ($.isArray(value)) {
 					if ($.isNumeric(value[1])) {
 						value[1] = +value[1];


### PR DESCRIPTION
Since 0.8, datas in format [[1, 80]] are not working. 
