### PR TITLE
Remove $.isNumeric() for compat with jQuery < 1.7. Fixes #1026

### DIFF
--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -181,12 +181,13 @@ More detail and specific examples can be found in the included HTML file.
 				// that the user may have stored in higher indexes.
 
 				if ($.isArray(value)) {
-					if ($.isNumeric(value[1])) {
+					// Equivalent to $.isNumeric() but compatible with jQuery < 1.7
+					if (!isNaN(parseFloat(value[1])) && isFinite(value[1])) {
 						value[1] = +value[1];
 					} else {
 						value[1] = 0;
 					}
-				} else if ($.isNumeric(value)) {
+				} else if (!isNaN(parseFloat(value)) && isFinite(value)) {
 					value = [1, +value];
 				} else {
 					value = [1, 0];


### PR DESCRIPTION
Remove $.isNumeric() for compat with jQuery < 1.7. Fixes #1026
