### PR TITLE
make dateGenerator public accessible

### DIFF
--- a/jquery.flot.time.js
+++ b/jquery.flot.time.js
@@ -427,5 +427,6 @@ API.txt for details.
 	// on the function, so we need to re-expose it here.
 
 	$.plot.formatDate = formatDate;
+	$.plot.dateGenerator = dateGenerator;
 
 })(jQuery);


### PR DESCRIPTION
It could be useful to access the dateGenerator method from external resources such as other plugins.
