### PR TITLE
Patch for colors array, issue #1031

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -642,7 +642,11 @@ Licensed under the MIT license.
 
             $.extend(true, options, opts);
             
-            if (opts.colors) options.colors = opts.colors;
+            //Override options.colors after $.extend if user has set colors, because extend does not clear out excess
+            //default colors if user defines color palette smaller than default palette size (currently 5).
+            if (opts.colors) {
+            	options.colors = opts.colors;
+            }
 
             if (options.xaxis.color == null)
                 options.xaxis.color = $.color.parse(options.grid.color).scale('a', 0.22).toString();


### PR DESCRIPTION
(Related to flot issue #1031: https://github.com/flot/flot/issues/1031)

Currently, if the user declares a custom color palette with less than 5 colors (say, n), $.extend(true, options, opts) only modifies the first n colors of the default palette and leaves the last 5-n in place. When the number of series is >n, colors are used that are not part of user-defined palette, contrary to description of colors array in API.

This line overrides the extended colors array and replaces it with exactly the user-defined colors array, when present. Afterwards, the user color palette is respected by the auto tinting/shading system for when there are more series than colors.

(If I've done this Pull Request thing wrong, I apologize. This is my first time, so let me know what I should have done instead, please.)

Edit: New commit to address dnschnur requests.
