### PR TITLE
updated threshold plugin to work with 'above' operator

### DIFF
--- a/jquery.flot.threshold.js
+++ b/jquery.flot.threshold.js
@@ -7,7 +7,8 @@ The plugin supports these options:
 
 	series: {
 		threshold: {
-			below: number
+			below: number,
+			above: mumber,
 			color: colorspec
 		}
 	}
@@ -22,10 +23,10 @@ It can also be applied to a single series, like this:
 An array can be passed for multiple thresholding, like this:
 
 	threshold: [{
-		below: number1
+		below: number1,
 		color: color1
 	},{
-		below: number2
+		above: number2,
 		color: color2
 	}]
 
@@ -46,9 +47,9 @@ You may need to check for this in hover events.
     var options = {
         series: { threshold: null } // or { below: number, color: color spec}
     };
-    
+
     function init(plot) {
-        function thresholdData(plot, s, datapoints, below, color) {
+        function thresholdData(plot, s, datapoints, below, above, color) {
             var ps = datapoints.pointsize, i, x, y, p, prevp,
                 thresholded = $.extend({}, s); // note: shallow copy
 
@@ -58,7 +59,7 @@ You may need to check for this in hover events.
             thresholded.threshold = null;
             thresholded.originSeries = s;
             thresholded.data = [];
- 
+
             var origpoints = datapoints.points,
                 addCrossingPoints = s.lines.show;
 
@@ -71,7 +72,7 @@ You may need to check for this in hover events.
                 y = origpoints[i + 1];
 
                 prevp = p;
-                if (y < below)
+                if (y < below || y > above)
                     p = threspoints;
                 else
                     p = newpoints;
@@ -83,7 +84,7 @@ You may need to check for this in hover events.
                     prevp.push(below);
                     for (m = 2; m < ps; ++m)
                         prevp.push(origpoints[i + m]);
-                    
+
                     p.push(null); // start new segment
                     p.push(null);
                     for (m = 2; m < ps; ++m)
@@ -102,41 +103,41 @@ You may need to check for this in hover events.
 
             datapoints.points = newpoints;
             thresholded.datapoints.points = threspoints;
-            
+
             if (thresholded.datapoints.points.length > 0) {
                 var origIndex = $.inArray(s, plot.getData());
                 // Insert newly-generated series right after original one (to prevent it from becoming top-most)
                 plot.getData().splice(origIndex + 1, 0, thresholded);
             }
-                
+
             // FIXME: there are probably some edge cases left in bars
         }
-        
+
         function processThresholds(plot, s, datapoints) {
             if (!s.threshold)
                 return;
-            
+
             if (s.threshold instanceof Array) {
                 s.threshold.sort(function(a, b) {
                     return a.below - b.below;
                 });
-                
+
                 $(s.threshold).each(function(i, th) {
-                    thresholdData(plot, s, datapoints, th.below, th.color);
+                    thresholdData(plot, s, datapoints, th.below, th.above, th.color);
                 });
             }
             else {
-                thresholdData(plot, s, datapoints, s.threshold.below, s.threshold.color);
+                thresholdData(plot, s, datapoints, s.threshold.below, s.threshold.above, s.threshold.color);
             }
         }
-        
+
         plot.hooks.processDatapoints.push(processThresholds);
     }
-    
+
     $.plot.plugins.push({
         init: init,
         options: options,
         name: 'threshold',
-        version: '1.2'
+        version: '1.3'
     });
 })(jQuery);


### PR DESCRIPTION
I have updated the threshhold plugin to work with the 'above' operator. It is now possible to color a data point if it is below a value OR above a value. This is useful for any data that may have an ideal range (E.G.: between 4 and 15); you may wish to color any bar below 4 or above 15 as red to indicate outside of preferred range.
