### PR TITLE
Bug in zoom functionality when using mouse wheel

### DIFF
--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -136,7 +136,7 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
 
         function onMouseWheel(e, delta) {
             e.preventDefault();
-            onZoomClick(e, delta < 0);
+            onZoomClick(e.originalEvent, e.originalEvent.wheelDelta < 0);
             return false;
         }
         


### PR DESCRIPTION
We need to use data from the original event as the wrapper doesn't have pageX, pageY and delta.
