### PR TITLE
Also stop at root when extracting CSS color

### DIFF
--- a/jquery.colorhelpers.js
+++ b/jquery.colorhelpers.js
@@ -74,13 +74,18 @@
     // if it's "transparent"
     $.color.extract = function (elem, css) {
         var c;
+        var parentElm;
         do {
             c = elem.css(css).toLowerCase();
             // keep going until we find an element that has color, or
-            // we hit the body
+            // we hit the body or root (have no parent)
             if (c != '' && c != 'transparent')
                 break;
-            elem = elem.parent();
+            parentElm = elem.parent();
+            if (null == parentElm.get(0)) {
+                break;
+            }
+            elem = parentElm;
         } while (!$.nodeName(elem.get(0), "body"));
 
         // catch Safari's way of signalling transparent


### PR DESCRIPTION
This change adds an additional check for whether the parent element is `null` or `undefined` in `$.color.extract`.  This can happen when working with elements that have not yet been added to the DOM under `<body>`.

Consider the following example pie chart.

``` js
var elm = $("<div />")
  .css({
    width: "240px"
  , height: "320px"
  })
var data = [
  {label: "One", data: "33"}
, {label: "Two", data: "33"}
, {label: "Three", data: "33"}
]
var opts = {
  legend: {
    show: true
  }
, series: {
    pie: {
      show: true
    }
  }
}
$.plot(elm, data, opts)
elm.appendTo($("body"))
```

When flot inserts each legend row, it tries to use the same color as the corresponding graph part, unless it was explicitly specified in the options.  However, in this example, `$.color.extract` runs into an unexpected `null` reference because `<body>` is not an ancestor of `elm`.  Specifically, a `TypeError: Cannot read property 'nodeName' of undefined` would be thrown.
