### PR TITLE
Change [olson] to http link

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,4 +107,4 @@ examples/axes-time-zones/index.html.
 [excanvas]: http://code.google.com/p/explorercanvas/
 [flashcanvas]: http://code.google.com/p/flashcanvas/
 [timezone-js]: https://github.com/mde/timezone-js
-[olson]: ftp://ftp.iana.org/tz/
+[olson]: http://ftp.iana.org/time-zones


### PR DESCRIPTION
GitHub doesn't render ftp links for some reason ([security?](https://github.com/mojombo/jekyll/issues/373#issuecomment-15025728)).
