### PR TITLE
Give access to the dateGenerator via $.plot.dateGenerator

### DIFF
--- a/jquery.flot.time.js
+++ b/jquery.flot.time.js
@@ -426,6 +426,7 @@ API.txt for details.
 	// formatDate function on the plot object.  Various plugins depend
 	// on the function, so we need to re-expose it here.
 
+	$.plot.dateGenerator = dateGenerator;
 	$.plot.formatDate = formatDate;
 
 })(jQuery);


### PR DESCRIPTION
This allows me to format dates in a hover or click event easily and have them in the same timezone as the ticks.

var time = $.plot.dateGenerator( item.datapoint[0], options.xaxis );
time = $.plot.formatDate(time, '%Y-%m-%d %H:%M:%S%P');

I have not followed the project much, so don't know if this is acceptable or wanted, but I added this patch locally so I could use it.
