### PR TITLE
Always remove the tick text in drawAxisLabels() regardless of axis settings

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2100,9 +2100,6 @@ Licensed under the MIT license.
         function drawAxisLabels() {
 
             $.each(allAxes(), function (_, axis) {
-                if (!axis.show || axis.ticks.length == 0)
-                    return;
-
                 var box = axis.box,
                     legacyStyles = axis.direction + "Axis " + axis.direction + axis.n + "Axis",
                     layer = "flot-" + axis.direction + "-axis flot-" + axis.direction + axis.n + "-axis " + legacyStyles,
@@ -2110,6 +2107,9 @@ Licensed under the MIT license.
                     tick, x, y, halign, valign;
 
                 surface.removeText(layer);
+
+                if (!axis.show || axis.ticks.length == 0)
+                    return;
 
                 for (var i = 0; i < axis.ticks.length; ++i) {
 


### PR DESCRIPTION
This fixes my tick-rotor plug-in. Since the ticks are created in the first pass, measured, but then removed, the text was never being deleted in the second pass.

In general, ticks can be drawn or an axis set to not be shown and then the graph redrawn, so we should be sure to always remove the tick text, even if there is none to be drawn.
