### PR TITLE
Pass dataIndex and series arguments to the symbol function, to allow shapes to vary by the original data.

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2670,8 +2670,10 @@ Licensed under the MIT license.
         function drawSeriesPoints(series) {
             function plotPoints(datapoints, radius, fillStyle, offset, shadow, axisx, axisy, symbol) {
                 var points = datapoints.points, ps = datapoints.pointsize;
-
+	            
+                var dataIndex = -1;
                 for (var i = 0; i < points.length; i += ps) {
+                    dataIndex++;
                     var x = points[i], y = points[i + 1];
                     if (x == null || x < axisx.min || x > axisx.max || y < axisy.min || y > axisy.max) {
                         continue;
@@ -2683,7 +2685,7 @@ Licensed under the MIT license.
                     if (symbol === "circle") {
                         ctx.arc(x, y, radius, 0, shadow ? Math.PI : Math.PI * 2, false);
                     } else {
-                        symbol(ctx, x, y, radius, shadow);
+                        symbol(ctx, x, y, radius, shadow, dataIndex, series);
                     }
                     ctx.closePath();
 


### PR DESCRIPTION
Based on my example here - http://stevesrunningcharts.apphb.com/
I wanted to be able to draw the more recent points in the chart larger.

Two commits are included - 
1. A bug fix. The axisOptions.axisLabel statements were blowing up, because the axisOptions hadn't been $.extend'ed yet. So I moved the $.extend's up in the code.
2. I added a couple arguments to the symbol(...) call - dataIndex, and series. dataIndex maps directly to the index of the original data source that is currently being drawn; series is so that I can tell which original data source to look at. 

There is another similar pull request out there...but it didn't pass the series, so I couldn't figure out how to find the item in the original data source.

Let me know what you think!
