### PR TITLE
Modify 'zoom in' behavior when close to an edge

### DIFF
--- a/src/plugins/jquery.flot.navigate.js
+++ b/src/plugins/jquery.flot.navigate.js
@@ -213,6 +213,20 @@ can set the default in the options.
                     }
                 };
 
+            // if zooming in when the mouse is close to an edge ('close' meaning
+            // within 10% of the total width) then keep that same edge after
+            // zoom (as opposed to ending up slightly inset from that edge)
+            if (amount > 1) {
+              // zooming in
+              if (xf > 0.9) {
+                // close to the right side
+                minmax.x.max = w;
+              } else if (xf < 0.1) {
+                // close to the left side
+                minmax.x.min = 0;
+              }
+            }
+
             $.each(plot.getAxes(), function(_, axis) {
                 var opts = axis.options,
                     min = minmax[axis.direction].min,


### PR DESCRIPTION
It's difficult to zoom in to the edge of a chart since, even if the mouse is very close to the edge, flot still zooms in from the edge a bit.

This PR changes the behavior to 'stick' to the edge when zooming in if the mouse is close to the edge ('close' meaning within 10% of the total width).
