### PR TITLE
Handle undefined axisOptions in 0.9-work

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -867,10 +867,10 @@ Licensed under the MIT license.
 
                 // Compatibility with markrcote/flot-axislabels
 
-                if (!axisOptions.label && axisOptions.axisLabel) {
+                if (axisOptions && !axisOptions.label && axisOptions.axisLabel) {
                     axisOptions.label = axisOptions.axisLabel;
                 }
-                if (!axisOptions.labelPadding && axisOptions.axisLabelPadding) {
+                if (axisOptions && !axisOptions.labelPadding && axisOptions.axisLabelPadding) {
                     axisOptions.labelPadding = axisOptions.axisLabelPadding;
                 }
 
@@ -899,10 +899,10 @@ Licensed under the MIT license.
 
                 // Compatibility with markrcote/flot-axislabels
 
-                if (!axisOptions.label && axisOptions.axisLabel) {
+                if (axisOptions && !axisOptions.label && axisOptions.axisLabel) {
                     axisOptions.label = axisOptions.axisLabel;
                 }
-                if (!axisOptions.labelPadding && axisOptions.axisLabelPadding) {
+                if (axisOptions && !axisOptions.labelPadding && axisOptions.axisLabelPadding) {
                     axisOptions.labelPadding = axisOptions.axisLabelPadding;
                 }
 


### PR DESCRIPTION
I ran into this issue when upgrading from 0.8.1 to 0.9-work.  Let me know if you need more details.  Thanks.
