### PR TITLE
Add option to lock the chart border to a grid

### DIFF
--- a/src/plugins/jquery.flot.navigate.js
+++ b/src/plugins/jquery.flot.navigate.js
@@ -218,7 +218,8 @@ can set the default in the options.
                     min = minmax[axis.direction].min,
                     max = minmax[axis.direction].max,
                     zr = opts.zoomRange,
-                    pr = opts.panRange;
+                    pr = opts.panRange,
+                    borderGridLock = opts.borderGridLock;
 
                 if (zr === false) { // no zooming on this axis
                     return;
@@ -248,6 +249,31 @@ can set the default in the options.
                     ((zr[0] != null && range < zr[0] && amount > 1) ||
                      (zr[1] != null && range > zr[1] && amount < 1))) {
                     return;
+                }
+
+                // lock to grid
+                if (borderGridLock) {
+                  if (amount > 1) {
+                    // zooming in
+                    var newMin = Math.round(min / borderGridLock) * borderGridLock;
+                    var newMax = Math.round(max / borderGridLock) * borderGridLock;
+                    if (newMin === opts.min && newMax === opts.max || newMin === newMax) {
+                      // didn't move in, or moved in too much
+                      if (opts.max - opts.min > borderGridLock) {
+                        // room to move in, nudge the side that wanted to move closer
+                        if (min - opts.min > opts.max - max) {
+                          newMin = opts.min + borderGridLock;
+                        } else {
+                          newMax = opts.max - borderGridLock;
+                        }
+                      }
+                    }
+                    min = newMin;
+                    max = newMax;
+                  } else {
+                    min = Math.floor(min / borderGridLock) * borderGridLock;
+                    max = Math.ceil(max / borderGridLock) * borderGridLock;
+                  }
                 }
 
                 opts.min = min;

--- a/src/plugins/jquery.flot.selection.js
+++ b/src/plugins/jquery.flot.selection.js
@@ -180,9 +180,19 @@ The plugin allso adds the following methods to the plot object:
 
             $.each(plot.getAxes(), function(name, axis) {
                 if (axis.used) {
-                    var p1 = axis.c2p(c1[axis.direction]),
-                        p2 = axis.c2p(c2[axis.direction]);
-                    r[name] = { from: Math.min(p1, p2), to: Math.max(p1, p2) };
+                    var p1 = axis.c2p(c1[axis.direction]), p2 = axis.c2p(c2[axis.direction]);
+                    var from = Math.min(p1, p2);
+                    var to = Math.max(p1, p2);
+                    // lock to grid
+                    var borderGridLock = axis.options.borderGridLock;
+                    if (borderGridLock) {
+                      from = Math.floor(from / borderGridLock) * borderGridLock;
+                      to = Math.ceil(to / borderGridLock) * borderGridLock;
+                      // deal with floating point precision, e.g. Math.floor(4.6 / .001) * .001 = 4.6000000000000005
+                      from = parseFloat(from.toPrecision(12));
+                      to = parseFloat(to.toPrecision(12));
+                    }
+                    r[name] = { from: from, to: to };
                 }
             });
             return r;


### PR DESCRIPTION
For example, lock a time series chart x-axis to 5-min increments.

Zooming and selection honor the new borderGridLock property.

I'm using this when I have aggregated time-series data with a single point every 5-min.
