### PR TITLE
Cancel selection mid-drag with esc key

### DIFF
--- a/src/plugins/jquery.flot.selection.js
+++ b/src/plugins/jquery.flot.selection.js
@@ -152,6 +152,11 @@ The plugin allso adds the following methods to the plot object:
                 document.ondrag = savedhandlers.ondrag;
             }
 
+            if (!selection.active) {
+                // selection was canceled by escape key
+                return;
+            }
+
             // no more dragging
             selection.active = false;
             updateSelection(e);
@@ -317,6 +322,13 @@ The plugin allso adds the following methods to the plot object:
             return Math.abs(selection.second.x - selection.first.x) >= minSize &&
                 Math.abs(selection.second.y - selection.first.y) >= minSize;
         }
+
+        $(document).keyup(function (e) {
+            if (e.keyCode === 27) { // esc key
+                clearSelection(true);
+                selection.active = false;
+            }
+        });
 
         plot.clearSelection = clearSelection;
         plot.setSelection = setSelection;


### PR DESCRIPTION
Allow user to change their mind mid-drag and cancel a "pending" selection zoom using the escape key.
