### PR TITLE
Highlight vertexes when no points

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -3278,10 +3278,17 @@ Licensed under the MIT license.
                 return;
             }
 
-            var pointRadius = series.points.radius + series.points.lineWidth / 2;
+            var pointRadius;
+            var radius;
+            if (series.points.show) {
+              pointRadius = series.points.radius + series.points.lineWidth / 2;
+              radius = 1.5 * pointRadius;
+            } else {
+              pointRadius = series.points.radius;
+              radius = 0.5 * pointRadius;
+            }
             octx.lineWidth = pointRadius;
             octx.strokeStyle = highlightColor;
-            var radius = 1.5 * pointRadius;
             x = axisx.p2c(x);
             y = axisy.p2c(y);
 


### PR DESCRIPTION
When `series.points.show` is false, currently a ring appears on highlight around where the point would have been.  This pull request changes that behavior to display a filled-in point on highlight.

Here's a jsfiddle of the current behavior: http://jsfiddle.net/trask/GrmYW/

Here's a jsfiddle using the patched jquery: http://jsfiddle.net/trask/xC2sF/
