### PR TITLE
Fix for #1117

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1070,8 +1070,9 @@ Licensed under the MIT license.
                     format.push({ y: true, number: true, required: true });
 
                     if (s.bars.show || (s.lines.show && s.lines.fill)) {
+                        var defaultValue = s.bars.show ? 0 : null;
                         var autoscale = !!((s.bars.show && s.bars.zero) || (s.lines.show && s.lines.zero));
-                        format.push({ y: true, number: true, required: false, defaultValue: 0, autoscale: autoscale });
+                        format.push({ y: true, number: true, required: false, defaultValue: defaultValue, autoscale: autoscale });
                         if (s.bars.horizontal) {
                             delete format[format.length - 1].y;
                             format[format.length - 1].x = true;


### PR DESCRIPTION
A fix for Issue #1117 (Null points cause the autoscale option to be ignored when using `fillBetween`).

Setting `defaultValue` to `null` (unless we are drawing bars) fixes the problem. That way the `min` value for the y-axis is not floored to zero before `fillBetween` gets the chance to run its hook and set actual bottom values.
