### PR TITLE
Instantiate barLeft/barRight in Bar Highlighting Section

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2791,6 +2791,8 @@ Licensed under the MIT license.
 
                 if (s.bars.show && !item) { // no other point can be nearby
 
+                    var barLeft, barRight;
+
                     switch (s.bars.align) {
                         case "left":
                             barLeft = 0;


### PR DESCRIPTION
Was having issues with highlighting and ran across this issue -- https://github.com/flot/flot/issues/1093

Which led me to the commit that fixed this issue so we could patch this on our version.  Worked great, but noticed in the commit (https://github.com/flot/flot/commit/2ce1139cf7ac97c3804c32f30154541a606a19c9) the instantiation for barLeft/barRight was accidentally removed.  This pull request adds back in the instantiation.
