### PR TITLE
Added plot.destroy() method, to properly destruct and release memory of plots.

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -658,6 +658,23 @@ Licensed under the MIT license.
             };
         };
         plot.shutdown = shutdown;
+        plot.destroy = function () {
+            shutdown();
+            placeholder.removeData("plot").empty();
+
+            series = [];
+            options = null;
+            surface = null;
+            overlay = null;
+            eventHolder = null;
+            ctx = null;
+            octx = null;
+            xaxes = [];
+            yaxes = [];
+            hooks = null;
+            highlights = [];
+            plot = null;
+        };
         plot.resize = function () {
         	var width = placeholder.width(),
         		height = placeholder.height();


### PR DESCRIPTION
Fixes #1129.
Flot's Plot objects now provide a destroy() method, (following the naming conventions of jquery-ui and other jquery plugins).
Plot.destroy() provides a way to properly remove the elements that were added to the DOM by Flot and properly release all the memory.

[Codepen demonstration](http://cdpn.io/IemKH) of the patch and comparison with the [old behavior](http://cdpn.io/imFjK).

10 plot create-destoy repetitions with GC.
Old memory timeline:
![flotleak](https://f.cloud.github.com/assets/1295829/1109940/3779400e-198a-11e3-90b0-d6d92692f46e.png)
New memory timeline:
![flotfix](https://f.cloud.github.com/assets/1295829/1109939/2e9fa658-198a-11e3-828f-b7bca383091a.png)
