### PR TITLE
flot.selection: bubble up the original event when triggering plotselecti...

### DIFF
--- a/jquery.flot.selection.js
+++ b/jquery.flot.selection.js
@@ -87,7 +87,7 @@ The plugin allso adds the following methods to the plot object:
             if (selection.active) {
                 updateSelection(e);
                 
-                plot.getPlaceholder().trigger("plotselecting", [ getSelection() ]);
+                plot.getPlaceholder().trigger("plotselecting", [ getSelection(), e ]);
             }
         }
 


### PR DESCRIPTION
...ng

I had to display a tooltip on selection (of a range), but unfortunately it was currently not possible as we don't have the original event.

This commit fix this.

Closes: https://github.com/flot/flot/issues/511
