### PR TITLE
Fixed a bug where plotting a chart crashes if the placeholder doesn't have a font size

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -737,7 +737,7 @@ Licensed under the MIT license.
             var i, axisOptions, axisCount,
                 fontDefaults = {
                     style: placeholder.css("font-style"),
-                    size: Math.round(0.8 * (+placeholder.css("font-size").replace("px", "") || 13)),
+                    size: Math.round(0.8 * (placeholder.css("font-size") ? +placeholder.css('font-size').replace("px", "") : 13)),
                     variant: placeholder.css("font-variant"),
                     weight: placeholder.css("font-weight"),
                     family: placeholder.css("font-family")


### PR DESCRIPTION
flot crashes if $placeholder element has no css font-size
