### PR TITLE
Update jquery.flot.threshold.js

### DIFF
--- a/jquery.flot.threshold.js
+++ b/jquery.flot.threshold.js
@@ -135,6 +135,26 @@ You may need to check for this in hover events.
         }
 
         plot.hooks.processDatapoints.push(processThresholds);
+        
+
+        function processThresholdsLegend(ctx, canvas, s) {
+            if (!s.threshold) {
+                return;
+            }
+
+            var color = s.threshold.color ? s.threshold.color : "black";
+
+            $(".legendLabel").each(function() {
+                if($(this).text() === s.label)
+                {
+                    var legend = $(this).prev().find("div > div");
+                    legend.css("border-right-color" , color);
+                    legend.css("border-bottom-color" , color);
+                }
+            });
+        }
+
+        plot.hooks.drawSeries.push(processThresholdsLegend);
     }
 
     $.plot.plugins.push({


### PR DESCRIPTION
Displays the serie base color and the threshold color side by side in the legend.
When no treshold is color is set, default black color is used.

![image](https://f.cloud.github.com/assets/1426742/1260161/450da602-2c03-11e3-8936-055eab75a27d.png)
