### PR TITLE
Rename component.json to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,8 @@
+{
+	"name": "Flot",
+	"version": "0.8.2-alpha",
+	"main": "jquery.flot.js",
+	"dependencies": {
+		"jquery": ">= 1.2.6"
+	}
+}


### PR DESCRIPTION
Flot was using the deprecated component.json for Bower support
