### PR TITLE
Avoid stacking when stack options are not defined

### DIFF
--- a/jquery.flot.stack.js
+++ b/jquery.flot.stack.js
@@ -57,7 +57,9 @@ charts or filled areas).
         }
 
         function stackData(plot, s, datapoints) {
-            if (s.stack == null || s.stack === false) {
+            // Reject for null, false and undefined
+            // But not for 0
+            if (((s.stack+"") !== "0") && !s.stack) {
                 return;
             }
 


### PR DESCRIPTION
When stacking plugin is included in the page but `stack: ...` options in `series` aren't defined, Flot attempts to stack the charts.

Following fix correctly avoids stacking for values `undefined` along with existing `null` and `false`. It however does not reject `0` (as expected).

**Note**: The seemingly hacky syntax (`((s.stack+"") !== "0")`) is actually to prevent jshint errors caused on using double equal to `==`
