### PR TITLE
Remove charAt calls

### DIFF
--- a/jquery.flot.categories.js
+++ b/jquery.flot.categories.js
@@ -162,7 +162,7 @@ as "categories" on the axis object, e.g. plot.getAxes().xaxis.categories.
         var points = datapoints.points,
             ps = datapoints.pointsize,
             format = datapoints.format,
-            formatColumn = axis.charAt(0),
+            formatColumn = axis[0],
             index = getNextIndex(categories);
 
         for (var i = 0; i < points.length; i += ps) {

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2988,14 +2988,14 @@ Licensed under the MIT license.
                 if (m[0] == null) {
                     m = [m, m];
                 }
-                if (p.charAt(0) === "n") {
+                if (p[0] === "n") {
                     pos += "top:" + (m[1] + plotOffset.top) + "px;";
-                } else if (p.charAt(0) === "s") {
+                } else if (p[0] === "s") {
                     pos += "bottom:" + (m[1] + plotOffset.bottom) + "px;";
                 }
-                if (p.charAt(1) === "e") {
+                if (p[1] === "e") {
                     pos += "right:" + (m[0] + plotOffset.right) + "px;";
-                } else if (p.charAt(1) === "w") {
+                } else if (p[1] === "w") {
                     pos += "left:" + (m[0] + plotOffset.left) + "px;";
                 }
                 var legend = $("<div class='legend'>" + table.replace("style='", "style='position:absolute;" + pos +";") + "</div>").appendTo(placeholder);

--- a/jquery.flot.time.js
+++ b/jquery.flot.time.js
@@ -65,7 +65,7 @@ API.txt for details.
 
         for (var i = 0; i < fmt.length; ++i) {
 
-            var c = fmt.charAt(i);
+            var c = fmt[i];
 
             if (escape) {
                 switch (c) {


### PR DESCRIPTION
Replace `charAt` calls with index lookup.
Index lookups are ~10% faster and save a few bytes
http://jsperf.com/charat-vs-index/2
