### PR TITLE
fix label's maxWidth calculation

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1347,7 +1347,7 @@ Licensed under the MIT license.
                 ticks = axis.ticks || [],
                 labelWidth = opts.labelWidth || 0,
                 labelHeight = opts.labelHeight || 0,
-                maxWidth = labelWidth || axis.direction == "x" ? Math.floor(surface.width / (ticks.length || 1)) : null,
+                maxWidth = labelWidth || (axis.direction == "x" ? Math.floor(surface.width / (ticks.length || 1)) : null),
                 legacyStyles = axis.direction + "Axis " + axis.direction + axis.n + "Axis",
                 layer = "flot-" + axis.direction + "-axis flot-" + axis.direction + axis.n + "-axis " + legacyStyles,
                 font = opts.font || "flot-tick-label tickLabel";


### PR DESCRIPTION
The check to assign maxWidth to labelWidth if it has a value is not properly computing.  This should correct the line to what I assume is the intended behavior.

I ran into this being a problem when needing to specify a custom labelWidth as an option.
