### PR TITLE
:not(selector , selector) isn't actually a valid CSS selector

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1252,7 +1252,9 @@ Licensed under the MIT license.
             // from a previous plot in this container that we'll try to re-use.
 
             placeholder.css("padding", 0) // padding messes up the positioning
-                .children(":not(.flot-base,.flot-overlay)").remove();
+                .children().filter(function(){
+                    return !$(this).hasClass("flot-overlay") && !$(this).hasClass('flot-base');
+                }).remove();
 
             if (placeholder.css("position") == 'static')
                 placeholder.css("position", "relative"); // for positioning labels and overlay


### PR DESCRIPTION
jQuery's Sizzle is the only thing that this actually works in so jQuery will fail when it passes this directly to `querySelectorAll()`

I have resolved this by splitting the `:not(selector, selector)` into a `:not(selector), :not(selector)` which is valid.
