### PR TITLE
Bower.json - Ignore rule edition

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,10 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "examples",
+    "*.md",
+    "*.json",
+    "*.txt"
   ]
 }


### PR DESCRIPTION
This adds markdown (`*.md`) files, txt (`*.txt`) files and the `examples` directory to the bower ignore rule.

Closes #1185
