### PR TITLE
Included tick pattern options and customise grid example

### DIFF
--- a/examples/customise-grid/index.html
+++ b/examples/customise-grid/index.html
@@ -1,0 +1,76 @@
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<title>Flot Examples: Customising the Grid</title>
+	<link href="../examples.css" rel="stylesheet" type="text/css">
+	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../excanvas.min.js"></script><![endif]-->
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+    <script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
+	<script type="text/javascript">
+
+	$(function() {
+
+		var d1 = [];
+		for (var i = 0; i < 14; i += 0.5) {
+			d1.push([i, Math.sin(i)]);
+		}
+
+		var d2 = [[0, 3], [4, 8], [8, 5], [9, 13]];
+
+		// A null signifies separate line segments
+
+		var d3 = [[0, 12], [7, 12], null, [7, 2.5], [12, 2.5]];
+
+		var options = {
+		    grid: {
+                color:"#335588", //
+		        borderWidth: 1,
+		        hoverable: true,
+		        clickable: true,
+		        borderColor: "#66AAFF",
+		        labelMargin: 20,		        
+		        tickPattern: {
+		            xaxis:
+                        { style: 'dotted' }, //set the tick pattern to dotted (same as dashed, [1,1])
+		            yaxis: {
+                            style: 'dashed', //set the tick pattern to dashed
+                            pattern: [12, 2] //set the interval to 12px filled 2px empty
+                        }
+		        }
+		    }
+		}
+
+		$.plot("#placeholder", [ d1, d2, d3 ],options);
+
+		// Add the Flot version string to the footer
+
+		$("#footer").prepend("Flot " + $.plot.version + " &ndash; ");
+	});
+
+    </script>
+</head>
+<body>
+
+	<div id="header">
+		<h2>Customise Grid</h2>
+	</div>
+
+	<div id="content">
+
+		<div class="demo-container">
+			<div id="placeholder" class="demo-placeholder"></div>
+		</div>
+
+		<p>It's very simple to customise the grid. Different colors for borders, background and ticks and three different tick patterns, solid, dotted and dashed. </p>
+		
+
+	</div>
+
+	<div id="footer">
+		Copyright &copy; 2007 - 2013 IOLA and Ole Laursen
+	</div>
+
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -68,6 +68,7 @@
 			<li><a href="series-errorbars/index.html">Plotting error bars</a> (with errorbars plugin)</li>
 			<li><a href="series-pie/index.html">Pie charts</a> (with pie plugin)</li>
 			<li><a href="canvas/index.html">Rendering text with canvas instead of HTML</a> (with canvas plugin)</li>
+            <li><a href="customise-grid/index.html">Customising the grid</a></li>
 		</ul>
 
 	</div>

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -695,6 +695,7 @@ Licensed under the MIT license.
                     backgroundColor: null, // null for transparent, else color
                     borderColor: null, // set if different from the grid color
                     tickColor: null, // color for the ticks, e.g. "rgba(0,0,0,0.15)"
+                    tickPattern: null, //pattern for the ticks. Solid, dashed or dotted
                     margin: 0, // distance from the canvas edge to the grid
                     labelMargin: 5, // in pixels
                     axisMargin: 8, // in pixels
@@ -2278,8 +2279,33 @@ Licensed under the MIT license.
                         }
                     }
 
-                    ctx.moveTo(x, y);
-                    ctx.lineTo(x + xoff, y + yoff);
+                    if (options.grid.tickPattern) {
+                        var style = null;
+                        var pattern = null;
+                        console.log(options.grid.tickPattern);
+                        if (axis.direction === "x" && options.grid.tickPattern.xaxis !== undefined) {
+                            style = options.grid.tickPattern.xaxis.style;
+                            pattern = options.grid.tickPattern.xaxis.pattern;
+                        } else if (axis.direction === "y" && options.grid.tickPattern.yaxis !== undefined) {
+                            style = options.grid.tickPattern.yaxis.style;;
+                            pattern = options.grid.tickPattern.yaxis.pattern;
+                        }
+
+                        console.log(style);
+                        if (style === 'dotted') {
+                            dashedLineTo(ctx, x, y, x + xoff, y + yoff, [1, 1]);
+                        } else if (style === 'dashed') {
+                            dashedLineTo(ctx, x, y, x + xoff, y + yoff, pattern);
+                        } else {  //if not defined or solid
+                            ctx.moveTo(x, y);
+                            ctx.lineTo(x + xoff, y + yoff);
+                        }
+
+                    }
+                    else {
+                        ctx.moveTo(x, y);
+                        ctx.lineTo(x + xoff, y + yoff);
+                    }
                 }
 
                 ctx.stroke();
@@ -2903,6 +2929,48 @@ Licensed under the MIT license.
             plotBars(series.datapoints, barLeft, barLeft + series.bars.barWidth, 0, fillStyleCallback, series.xaxis, series.yaxis);
             ctx.restore();
         }
+
+        //draw a dashed line on the given ctx, in the given coordinates, following the given pattern
+
+        function dashedLineTo(ctx, fromX, fromY, toX, toY, pattern) {
+
+            //taken from: http://davidowens.wordpress.com/2010/09/07/html-5-canvas-and-dashed-lines/ and modified a little            
+
+            var lt = function (a, b) { return a <= b; };
+            var gt = function (a, b) { return a >= b; };
+            var capmin = function (a, b) { return Math.min(a, b); };
+            var capmax = function (a, b) { return Math.max(a, b); };
+
+            var checkX = { thereYet: gt, cap: capmin };
+            var checkY = { thereYet: gt, cap: capmin };
+
+            if (fromY - toY > 0) {
+                checkY.thereYet = lt;
+                checkY.cap = capmax;
+            }
+            if (fromX - toX > 0) {
+                checkX.thereYet = lt;
+                checkX.cap = capmax;
+            }
+
+            ctx.moveTo(fromX, fromY);
+            var offsetX = fromX;
+            var offsetY = fromY;
+            var idx = 0, dash = true;
+            while (!(checkX.thereYet(offsetX, toX) && checkY.thereYet(offsetY, toY))) {
+                var ang = Math.atan2(toY - fromY, toX - fromX);
+                var len = pattern[idx];
+
+                offsetX = checkX.cap(toX, offsetX + (Math.cos(ang) * len));
+                offsetY = checkY.cap(toY, offsetY + (Math.sin(ang) * len));
+
+                if (dash) ctx.lineTo(offsetX, offsetY);
+                else ctx.moveTo(offsetX, offsetY);
+
+                idx = (idx + 1) % pattern.length;
+                dash = !dash;
+            }
+        };
 
         function getFillStyle(filloptions, seriesColor, bottom, top) {
             var fill = filloptions.fill;


### PR DESCRIPTION
I've added options to get a dashed or a dotted patter in the ticks instead of a solid line. You can set the style to "dotted", "dashed" or "solid", and an array with the dashed pattern interval. The pattern is ignored if the style is different than dashed and if nothing is given the default solid line is displayed.

The inspiration (and most of the source) came from this question on stackoverflow: http://stackoverflow.com/questions/14700417/dashed-ticklines-gridlines-in-flot

```
    grid: {                         
    tickPattern: {
             xaxis: { 
                               style: 'dotted'  //set the tick pattern to dotted (same as dashed, [1,1])
                        },
              yaxis: {
                        style: 'dashed', //set the tick pattern to dashed
                        pattern: [12, 2] //set the interval to 12px filled 2px empty
                    }
     }
    }
```
