### PR TITLE
Add missing references and minor update on jquery.flot.js.

### DIFF
--- a/examples/ajax/index.html
+++ b/examples/ajax/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/annotating/index.html
+++ b/examples/annotating/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/axes-interacting/index.html
+++ b/examples/axes-interacting/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/axes-multiple/index.html
+++ b/examples/axes-multiple/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.time.js"></script>
 	<script type="text/javascript">

--- a/examples/axes-time-zones/index.html
+++ b/examples/axes-time-zones/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.time.js"></script>
 	<script language="javascript" type="text/javascript" src="date.js"></script>

--- a/examples/axes-time/index.html
+++ b/examples/axes-time/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.time.js"></script>
 	<script type="text/javascript">

--- a/examples/basic-options/index.html
+++ b/examples/basic-options/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/basic-usage/index.html
+++ b/examples/basic-usage/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/canvas/index.html
+++ b/examples/canvas/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.time.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.canvas.js"></script>

--- a/examples/categories/index.html
+++ b/examples/categories/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.categories.js"></script>
 	<script type="text/javascript">

--- a/examples/image/index.html
+++ b/examples/image/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.image.js"></script>
 	<script type="text/javascript">

--- a/examples/interacting/index.html
+++ b/examples/interacting/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/navigate/index.html
+++ b/examples/navigate/index.html
@@ -25,6 +25,7 @@
 	</style>
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.navigate.js"></script>
 	<script type="text/javascript">

--- a/examples/percentiles/index.html
+++ b/examples/percentiles/index.html
@@ -5,7 +5,8 @@
 	<title>Flot Examples: Percentiles</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
-	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>	
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.fillbetween.js"></script>
 	<script type="text/javascript">

--- a/examples/realtime/index.html
+++ b/examples/realtime/index.html
@@ -5,7 +5,8 @@
 	<title>Flot Examples: Real-time updates</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
-	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>	
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/resize/index.html
+++ b/examples/resize/index.html
@@ -7,6 +7,7 @@
 	<link href="../shared/jquery-ui/jquery-ui.min.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../shared/jquery-ui/jquery-ui.min.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.resize.js"></script>

--- a/examples/selection/index.html
+++ b/examples/selection/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.selection.js"></script>
 	<script type="text/javascript">

--- a/examples/series-errorbars/index.html
+++ b/examples/series-errorbars/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.errorbars.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.navigate.js"></script>

--- a/examples/series-pie/index.html
+++ b/examples/series-pie/index.html
@@ -77,6 +77,7 @@
 	</style>
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.pie.js"></script>
 	<script type="text/javascript">

--- a/examples/series-toggle/index.html
+++ b/examples/series-toggle/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/stacking/index.html
+++ b/examples/stacking/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.stack.js"></script>
 	<script type="text/javascript">

--- a/examples/symbols/index.html
+++ b/examples/symbols/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.symbol.js"></script>
 	<script type="text/javascript">

--- a/examples/threshold/index.html
+++ b/examples/threshold/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.threshold.js"></script>
 	<script type="text/javascript">

--- a/examples/tracking/index.html
+++ b/examples/tracking/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.crosshair.js"></script>
 	<script type="text/javascript">

--- a/examples/visitors/index.html
+++ b/examples/visitors/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.time.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.selection.js"></script>

--- a/examples/zooming/index.html
+++ b/examples/zooming/index.html
@@ -6,6 +6,7 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../lib/excanvas.min.js"></script><![endif]-->
 	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.selection.js"></script>
 	<script type="text/javascript">


### PR DESCRIPTION
- Add jquery.colorhelpers.js reference to example pages;
- Minor update on jquery.flot.js. (Fix the error message in the canvas example page)  -- Reverted the change.
