### PR TITLE
Default lineHeight based on the font size.

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -762,8 +762,6 @@ Licensed under the MIT license.
                     family: placeholder.css("font-family")
                 };
 
-            fontDefaults.lineHeight = fontDefaults.size * 1.15;
-
             axisCount = options.xaxes.length || 1;
             for (i = 0; i < axisCount; ++i) {
 
@@ -779,6 +777,9 @@ Licensed under the MIT license.
                     axisOptions.font = $.extend({}, fontDefaults, axisOptions.font);
                     if (!axisOptions.font.color) {
                         axisOptions.font.color = axisOptions.color;
+                    }
+                    if (!axisOptions.font.lineHeight) {
+                        axisOptions.font.lineHeight = Math.round(axisOptions.font.size * 1.15);
                     }
                 }
             }
@@ -798,6 +799,9 @@ Licensed under the MIT license.
                     axisOptions.font = $.extend({}, fontDefaults, axisOptions.font);
                     if (!axisOptions.font.color) {
                         axisOptions.font.color = axisOptions.color;
+                    }
+                    if (!axisOptions.font.lineHeight) {
+                        axisOptions.font.lineHeight = Math.round(axisOptions.font.size * 1.15);
                     }
                 }
             }


### PR DESCRIPTION
Flot 0.8.0 used the default font size, typically derived from the
placeholder, as the basis for the default lineHeight.  This produced
incorrect results when a font.size was provided explicitly, and it
differed from the placeholder’s CSS size.

Fixed by waiting to default lineHeight until the actual font size has
been resolved.  Fixes #1131.
