### PR TITLE
Don't add padding when there's no last tick.

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1480,7 +1480,7 @@ Licensed under the MIT license.
             // inside the canvas and isn't clipped off
 
             var minMargin = options.grid.minBorderMargin,
-                margins = { x: 0, y: 0 }, i, axis;
+                axis, i;
 
             // check stuff from the plot (FIXME: this should just read
             // a value from the series, otherwise it's impossible to
@@ -1491,21 +1491,37 @@ Licensed under the MIT license.
                     minMargin = Math.max(minMargin, 2 * (series[i].points.radius + series[i].points.lineWidth/2));
             }
 
-            margins.x = margins.y = Math.ceil(minMargin);
+            var margins = {
+                left: minMargin,
+                right: minMargin,
+                top: minMargin,
+                bottom: minMargin
+            };
 
             // check axis labels, note we don't check the actual
             // labels but instead use the overall width/height to not
             // jump as much around with replots
             $.each(allAxes(), function (_, axis) {
-                var dir = axis.direction;
-                if (axis.reserveSpace)
-                    margins[dir] = Math.ceil(Math.max(margins[dir], (dir == "x" ? axis.labelWidth : axis.labelHeight) / 2));
+                var lastTick = axis.ticks[axis.ticks.length - 1];
+                if (axis.reserveSpace && lastTick) {
+                    if (axis.direction === "x") {
+                        margins.left = Math.max(margins.left, axis.labelWidth / 2);
+                        if (lastTick.v <= axis.max) {
+                            margins.right = Math.max(margins.right, axis.labelWidth / 2);
+                        }
+                    } else {
+                        margins.bottom = Math.max(margins.bottom, axis.labelHeight / 2);
+                        if (lastTick.v <= axis.max) {
+                            margins.top = Math.max(margins.top, axis.labelHeight / 2);
+                        }
+                    }
+                }
             });
 
-            plotOffset.left = Math.max(margins.x, plotOffset.left);
-            plotOffset.right = Math.max(margins.x, plotOffset.right);
-            plotOffset.top = Math.max(margins.y, plotOffset.top);
-            plotOffset.bottom = Math.max(margins.y, plotOffset.bottom);
+            plotOffset.left = Math.ceil(Math.max(margins.left, plotOffset.left));
+            plotOffset.right = Math.ceil(Math.max(margins.right, plotOffset.right));
+            plotOffset.top = Math.ceil(Math.max(margins.top, plotOffset.top));
+            plotOffset.bottom = Math.ceil(Math.max(margins.bottom, plotOffset.bottom));
         }
 
         function setupGrid() {


### PR DESCRIPTION
Flot 0.8 added logic to account for the size of axis tick labels and add padding around the edges of the plot, to prevent long labels from sticking out.  But it padded both sides equally, which is incorrect if the right/top side has no last axis label.

Fixed by allocating padding per-side, and checking whether the last label would be shown before padding the top or right.  Fixes #1048.
