### PR TITLE
Proposed fix for issue 1204: only enforce zoom limits in the direction of the merge

### DIFF
--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -260,8 +260,8 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
 
                 var range = max - min;
                 if (zr &&
-                    ((zr[0] != null && range < zr[0]) ||
-                     (zr[1] != null && range > zr[1])))
+                    ((zr[0] != null && range < zr[0] && amount >1) ||
+                     (zr[1] != null && range > zr[1] && amount <1)))
                     return;
             
                 opts.min = min;


### PR DESCRIPTION
Short patch for flot.zoom that only enforces one limit or the other, depending on the direction of the zoom.
