### PR TITLE
Exposing the hardcoded defaultValue property as a configuration option for Lines

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -672,9 +672,12 @@ Licensed under the MIT license.
                         lineWidth: 2, // in pixels
                         fill: false,
                         fillColor: null,
-                        steps: false
+                        steps: false,
                         // Omit 'zero', so we can later default its value to
                         // match that of the 'fill' option.
+                        defaultValue: 0
+                        // Additional option parameter for lines to set the 
+                        // default value used to control where the 'fill' will originate from.
                     },
                     bars: {
                         show: false,
@@ -1319,7 +1322,7 @@ Licensed under the MIT license.
 
                     if (s.bars.show || (s.lines.show && s.lines.fill)) {
                         var autoscale = !!((s.bars.show && s.bars.zero) || (s.lines.show && s.lines.zero));
-                        format.push({ y: true, number: true, required: false, defaultValue: 0, autoscale: autoscale });
+                        format.push({ y: true, number: true, required: false, defaultValue: s.lines.defaultValue, autoscale: autoscale });
                         if (s.bars.horizontal) {
                             delete format[format.length - 1].y;
                             format[format.length - 1].x = true;


### PR DESCRIPTION
I had the need to create a chart that would point out deviation from a set goal.
I.E. Historical Student attendance goal of 80%.

As you can see in figure 1 when activating the fill:true parameter the fill will take a baseline of 0 (which is a hardcoded value).
Figure 1.
![before](https://f.cloud.github.com/assets/573569/2033238/e482a98a-8919-11e3-959f-cf85be84fefc.png)

In figure 2 I have the chart working as I need it and probably others do. (exposing the property as a configuration value in the Lines properties.
Figure 2.
![after](https://f.cloud.github.com/assets/573569/2033707/66d54770-8920-11e3-8095-64f1fc36d510.png)

Change is very simple please look at the diff.
