### PR TITLE
Lowercase name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "Flot",
+	"name": "flot",
 	"version": "0.8.3-alpha",
 	"main": "jquery.flot.js",
 	"scripts": {


### PR DESCRIPTION
Names of packages in the npm registry must be lowercase, thus I think it makes sense to follow that rule even if something isn't in the registry (I simply reference the flot repo in my package json so npm installs it for me - it looks much nicer when all names are lowercase :smile:).
