### PR TITLE
Pie: Fix combined data to keep all other original values.

### DIFF
--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -225,7 +225,8 @@ More detail and specific examples can be found in the included HTML file.
 				var value = data[i].data[0][1];
 				if (numCombined < 2 || value / total > options.series.pie.combine.threshold) {
 					newdata.push(
-						$.extend(data[i], {
+						$.extend(data[i], {     /* extend to allow keeping all other original data values
+						                           and using them e.g. in labelFormatter. */
 							data: [[1, value]],
 							color: data[i].color,
 							label: data[i].label,


### PR DESCRIPTION
Fix combined data to keep all other original values but not only data, color, label, angle, percent as was before.
Allows to store own values in series and use them e.g. in `labelFormatter`.
