### PR TITLE
fix browser detection for jQuery > 2.0

### DIFF
--- a/src/jquery.flot.js
+++ b/src/jquery.flot.js
@@ -361,6 +361,9 @@ Licensed under the MIT license.
                     c = sin.toFixed(6),     // when we add them to the string
                     transformRule;
 
+                // Detect IE7/8 to use microsofts proprietary matrix filter
+                // $.support.leadingWhitespace is false on IE7/8, true on other browsers and
+                // undefined with jQuery greater 2.0, which dropped support for IE7/8.
                 if ($.support.leadingWhitespace !== false) {
 
                     // The transform origin defaults to '50% 50%', producing


### PR DESCRIPTION
jQuery removed $.support.leadingWhitespace from jquery greater 2.0
because support was dropped for IE 7/8. So if property is undefined,
we are pretty shure its ie > 8 or jQuery does not support the browser
anyway.
