### PR TITLE
hide lines between base and lower/upper caps?

### DIFF
--- a/jquery.flot.errorbars.js
+++ b/jquery.flot.errorbars.js
@@ -23,6 +23,7 @@ The plugin supports these options:
 				asymmetric: null/false or true,
 				upperCap: null or "-" or function,
 				lowerCap: null or "-" or function,
+				hideLines: null/false or true,
 				color: null or color,
 				radius: null or number
 			},
@@ -279,20 +280,22 @@ shadowSize and lineWidth are derived as well from the points series.
         upper += offset;
         lower += offset;
 
-        // error bar - avoid plotting over circles
-        if (err.err == 'x'){
-            if (upper > x + radius) drawPath(ctx, [[upper,y],[Math.max(x + radius,minmax[0]),y]]);
-            else drawUpper = false;
-            if (lower < x - radius) drawPath(ctx, [[Math.min(x - radius,minmax[1]),y],[lower,y]] );
-            else drawLower = false;
-        }
-        else {
-            if (upper < y - radius) drawPath(ctx, [[x,upper],[x,Math.min(y - radius,minmax[0])]] );
-            else drawUpper = false;
-            if (lower > y + radius) drawPath(ctx, [[x,Math.max(y + radius,minmax[1])],[x,lower]] );
-            else drawLower = false;
-        }
-
+	// draw lines between base points and upper/lower caps?
+	if (!err.hideLines) {
+	    // error bar - avoid plotting over circles
+	    if (err.err == 'x'){
+	        if (upper > x + radius) drawPath(ctx, [[upper,y],[Math.max(x + radius,minmax[0]),y]]);
+	        else drawUpper = false;
+	        if (lower < x - radius) drawPath(ctx, [[Math.min(x - radius,minmax[1]),y],[lower,y]] );
+	        else drawLower = false;
+	    }
+	    else {
+	        if (upper < y - radius) drawPath(ctx, [[x,upper],[x,Math.min(y - radius,minmax[0])]] );
+	        else drawUpper = false;
+	        if (lower > y + radius) drawPath(ctx, [[x,Math.max(y + radius,minmax[1])],[x,lower]] );
+	        else drawLower = false;
+	    }
+	}
         //internal radius value in errorbar, allows to plot radius 0 points and still keep proper sized caps
         //this is a way to get errorbars on lines without visible connecting dots
         radius = err.radius != null? err.radius: radius;


### PR DESCRIPTION
If the new hideLines property is set to true, lines between base circle and lower/upper caps are not drawn.
This is non-intrusive change, without specifying the attribute, everything works the same as before.
If the graph is overfilled with lines, setting this property may help to keep it cleaner.
