### PR TITLE
 Pan trigger extended to contain information if the dragging has ended or not

### DIFF
--- a/src/plugins/jquery.flot.navigate.js
+++ b/src/plugins/jquery.flot.navigate.js
@@ -157,7 +157,7 @@ can set the default in the options.
             plot.getPlaceholder().css("cursor", prevCursor);
             plot.pan({ left: prevPageX - e.pageX,
                        top: prevPageY - e.pageY,
-                       dragEnded: true, });
+                       dragEnded: true });
         }
 
         function bindEvents(plot, eventHolder) {


### PR DESCRIPTION
As I do not know how to change the pull request #1255, I create this new one.

If navigate plugin is used with pan functionality and data needs to be reloaded, it may be usefull to avoid calling the pan trigger during dragging.

This can help to avoid constantsly reloading data during dragging and instead just reload data, when dragging has been finished.
