### PR TITLE
correct tickGenerator calculation edge case.

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1731,7 +1731,7 @@ Licensed under the MIT license.
                         v = start + i * axis.tickSize;
                         ticks.push(v);
                         ++i;
-                    } while (v < axis.max && v != prev);
+                    } while (v <= axis.max && v != prev);
                     return ticks;
                 };
 


### PR DESCRIPTION
During real-time plot updates, if the following option is enabled:
  "xaxis: {show: true}"

then the original calculation in tickGenerator() would draw the right
edge of the chart in two different locations as xaxis.max increased. The final tick at
(axis.max%tickSize==0) was omitted, and the right edge was drawn slightly
to the left. This resulted in jumpy display on rapid updates.

This patch changes the less-than condition to less-than-or-equal. As a
result, the right edge is drawn in a consistent location. And,
tickGenerator() returns a tick when (axis.max%tickSize==0).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flot/flot/1273)

<!-- Reviewable:end -->
