### PR TITLE
Verify options have been set before referencing from drawDonutHole

### DIFF
--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -69,7 +69,6 @@ More detail and specific examples can be found in the included HTML file.
 
 		var canvas = null,
 			target = null,
-			options = null,
 			maxRadius = null,
 			centerLeft = null,
 			centerTop = null,
@@ -155,14 +154,14 @@ More detail and specific examples can be found in the included HTML file.
 				processed = true;
 				canvas = plot.getCanvas();
 				target = $(canvas).parent();
-				options = plot.getOptions();
 				plot.setData(combine(plot.getData()));
 			}
 		}
 
 		function combine(data) {
 
-			var total = 0,
+			var options = plot.getOptions(),
+                total = 0,
 				combined = 0,
 				numCombined = 0,
 				color = options.series.pie.combine.color,
@@ -256,7 +255,8 @@ More detail and specific examples can be found in the included HTML file.
 				return; // if no series were passed
 			}
 
-			var canvasWidth = plot.getPlaceholder().width(),
+			var options = plot.getOptions(),
+                canvasWidth = plot.getPlaceholder().width(),
 				canvasHeight = plot.getPlaceholder().height(),
 				legendWidth = target.children().filter(".legend").children().width() || 0;
 
@@ -533,7 +533,9 @@ More detail and specific examples can be found in the included HTML file.
 		// Placed here because it needs to be accessed from multiple locations
 
 		function drawDonutHole(layer) {
-			if (options && options.series.pie.innerRadius > 0) {
+            var options = plot.getOptions();
+            
+			if (options.series.pie.innerRadius > 0) {
 
 				// subtract the center
 
@@ -652,13 +654,18 @@ More detail and specific examples can be found in the included HTML file.
 		// trigger click or hover event (they send the same parameters so we share their code)
 
 		function triggerClickHoverEvent(eventname, e) {
+            if (!target) {
+				return; // if no series were passed
+			}
+            
+			var options = plot.getOptions(),
+                offset = plot.offset();
 
-			var offset = plot.offset();
 			var canvasX = parseInt(e.pageX - offset.left);
 			var canvasY =  parseInt(e.pageY - offset.top);
 			var item = findNearbySlice(canvasX, canvasY);
 
-			if (options && options.grid.autoHighlight) {
+			if (options.grid.autoHighlight) {
 
 				// clear auto-highlights
 


### PR DESCRIPTION
This can occur when the pie has no data in it.  Without this the code throws when no data has been specified
