### PR TITLE
Ignore non shown series for autoscaling

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1198,6 +1198,9 @@ Licensed under the MIT license.
             // second pass: find datamax/datamin for auto-scaling
             for (i = 0; i < series.length; ++i) {
                 s = series[i];
+                if (!s.lines.show && !s.bars.show && !s.points.show)
+                    continue;
+
                 points = s.datapoints.points;
                 ps = s.datapoints.pointsize;
                 format = s.datapoints.format;


### PR DESCRIPTION
If the show property is false for lines, bars and points, then
this serie is ignored for the autoscaling.
