### PR TITLE
Allow x2axis/y2axis with no min/max to auto-scale.

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -814,10 +814,24 @@ Licensed under the MIT license.
             if (options.x2axis) {
                 options.xaxes[1] = $.extend(true, {}, options.xaxis, options.x2axis);
                 options.xaxes[1].position = "top";
+                // Override the inherit to allow the axis to auto-scale
+                if (options.x2axis.min == null) {
+                    options.xaxes[1].min = null;
+                }
+                if (options.x2axis.max == null) {
+                    options.xaxes[1].max = null;
+                }
             }
             if (options.y2axis) {
                 options.yaxes[1] = $.extend(true, {}, options.yaxis, options.y2axis);
                 options.yaxes[1].position = "right";
+                // Override the inherit to allow the axis to auto-scale
+                if (options.y2axis.min == null) {
+                    options.yaxes[1].min = null;
+                }
+                if (options.y2axis.max == null) {
+                    options.yaxes[1].max = null;
+                }
             }
             if (options.grid.coloredAreas)
                 options.grid.markings = options.grid.coloredAreas;


### PR DESCRIPTION
Using x2axis/y2axis to add a second axis is deprecated, but we
currently still support it.  Historically we’ve just extended the first
axis’s options with the second’s, but that is a problem when the first
has min/max and the second doesn’t; it will inherit an inappropriate
min/max.

We might want to consider not extending at all, but since that’s a
bigger change we’ll for now just ensure that if no min/max is
specified, we respect that.

Fixes #1228.
