### PR TITLE
Provide a detach shim for jQuery prior to 1.4.

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -38,6 +38,22 @@ Licensed under the MIT license.
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 
+    // A shim to provide 'detach' to jQuery versions prior to 1.4.  Using a DOM
+    // operation produces the same effect as detach, i.e. removing the element
+    // without touching its jQuery data.
+
+    // Do not merge this into Flot 0.9, since it requires jQuery 1.4.4+.
+
+    if (!$.fn.detach) {
+        $.fn.detach = function() {
+            return this.each(function() {
+                if (this.parentNode) {
+                    this.parentNode.removeChild( this );
+                }
+            });
+        };
+    }
+
 	///////////////////////////////////////////////////////////////////////////
 	// The Canvas object is a wrapper around an HTML5 <canvas> tag.
 	//


### PR DESCRIPTION
Flot 0.8 still officially supports jQuery 1.2.6 and higher, so we can’t
assume the existence of detach.  This will go away in 0.9, where the
minimum jQuery version is 1.4.4.

Fixes #1240.
