### PR TITLE
add bower.json, ignore unneeded files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+	"name": "Flot",
+	"version": "0.8.3",
+	"main": "jquery.flot.js",
+	"dependencies": {
+		"jquery": ">= 1.2.6"
+	},
+	"ignore": [
+		"**/.*",
+		"*.md",
+		"component.json",
+		"jquery.js",
+		"LICENSE.txt",
+		"Makefile",
+		"package.json",
+                "examples"
+	]
+}


### PR DESCRIPTION
A bower-specific config file with ignore setting to leave out files not needed when installing via bower.