### PR TITLE
removing appending warning to dom

### DIFF
--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -325,7 +325,9 @@ More detail and specific examples can be found in the included HTML file.
 
 			if (attempts >= REDRAW_ATTEMPTS) {
 				clear();
-				target.prepend("<div class='error'>Could not draw pie with labels contained inside canvas</div>");
+				if ( typeof console === 'object' && typeof console.warn === 'function' ) {
+					console.warn("Could not draw pie with labels contained inside canvas");
+				}
 			}
 
 			if (plot.setSeries && plot.insertLegend) {


### PR DESCRIPTION
Message does not get cleared out properly as well as causing crazy view while a resize event happens.

![screenshot from 2014-05-14 14 11 22](https://cloud.githubusercontent.com/assets/578259/2977812/2f159f1e-dbb0-11e3-8f79-23d97d56783e.png)

This will just `console.warn` the message instead
