### PR TITLE
removing appending warning to dom

### DIFF
--- a/src/plugins/jquery.flot.pie.js
+++ b/src/plugins/jquery.flot.pie.js
@@ -254,6 +254,8 @@ More detail and specific examples can be found in the included HTML file.
 
         function draw(plot, newCtx) {
 
+            /* global console */
+
             if (!target) {
                 return; // if no series were passed
             }
@@ -327,7 +329,7 @@ More detail and specific examples can be found in the included HTML file.
 
             if (attempts >= REDRAW_ATTEMPTS) {
                 clear();
-                if ( typeof console === 'object' && typeof console.warn === 'function' ) {
+                if ( typeof console === "object" && typeof console.warn === "function" ) {
                     console.warn("Could not draw pie with labels contained inside canvas");
                 }
             }


### PR DESCRIPTION
moved from `master` to `0.9-work` as requested #1308
