### PR TITLE
Don't add an ID to every pie label

### DIFF
--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -492,10 +492,9 @@ More detail and specific examples can be found in the included HTML file.
 						var x = centerLeft + Math.round(Math.cos(halfAngle) * radius);
 						var y = centerTop + Math.round(Math.sin(halfAngle) * radius) * options.series.pie.tilt;
 
-						var html = "<span class='pieLabel' id='pieLabel" + index + "' style='position:absolute;top:" + y + "px;left:" + x + "px;'>" + text + "</span>";
-						target.append(html);
+						var label = $('<span/>').addClass("pieLabel").attr('style', "position:absolute;top:" + y + "px;left:" + x + "px;").html(text);
+						target.append(label);
 
-						var label = target.children("#pieLabel" + index);
 						var labelTop = (y - label.height() / 2);
 						var labelLeft = (x - label.width() / 2);
 


### PR DESCRIPTION
This causes issues on pages with more than one pie chart, as duplicate label IDs are created, which can cause issues with accessibility (http://www.w3.org/TR/WCAG20-TECHS/F77).

Additionally, the use case for having an ID on each pie chart label seems to be negligible / non-existent, and it appeared to be simply a means of selecting the label further down in the code which is not necessary.
