### PR TITLE
Changed bottom to y1

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -3142,10 +3142,7 @@ Licensed under the MIT license.
     // Add the plot function to the top level of the jQuery object
 
     $.plot = function(placeholder, data, options) {
-        //var t0 = new Date();
-        var plot = new Plot($(placeholder), data, options, $.plot.plugins);
-        //(window.console ? console.log : alert)("time used (msecs): " + ((new Date()).getTime() - t0.getTime()));
-        return plot;
+        return new Plot($(placeholder), data, options, $.plot.plugins);
     };
 
     $.plot.version = "0.8.3";


### PR DESCRIPTION
Corrects an Issue found to only occur in Chrome for Windows 7 and Android, as reported in:
https://github.com/flot/flot/issues/1352

By having the coordinate set to bottom, the chart would plot an area starting from the bottom of the charting area, whereas what we actually want is for the chart to start plotting this area from the points of the first coordinate (x1, y1).

tl;dr: We want to plot from (x1,y1) instead of (x1,bottom).
