### PR TITLE
Update jquery.flot.categories.js

### DIFF
--- a/jquery.flot.categories.js
+++ b/jquery.flot.categories.js
@@ -103,6 +103,10 @@ as "categories" on the axis object, e.g. plot.getAxes().xaxis.categories.
 
         return index + 1;
     }
+    
+    function categoriesTickFormatter(v,axis) {
+    	return v; // So flot.tooltip works properly with categories
+    }
 
     function categoriesTickGenerator(axis) {
         var res = [];
@@ -139,6 +143,9 @@ as "categories" on the axis object, e.g. plot.getAxes().xaxis.categories.
         // fix ticks
         if (!series[axis].options.ticks)
             series[axis].options.ticks = categoriesTickGenerator;
+
+	if (!series[axis].options.tickFormatter)
+            series[axis].options.tickFormatter = categoriesTickFormatter;
 
         transformPointsOnAxis(datapoints, axis, series[axis].categories);
     }


### PR DESCRIPTION
Fixing default tickFormatter with categories so flot.tooltip plugin (Krysztof Urbas) does not use numeric format of categories (x values) and accidentally format as "NaN.00"
