### PR TITLE
Add an optional third parameter to ticks to hide the corresponding grid line

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1837,18 +1837,21 @@ Licensed under the MIT license.
             axis.ticks = [];
             for (i = 0; i < ticks.length; ++i) {
                 var label = null;
+                var showGrid = true;
                 var t = ticks[i];
                 if (typeof t == "object") {
                     v = +t[0];
                     if (t.length > 1)
                         label = t[1];
+                    if (t.length > 2)
+                        showGrid = t[2];
                 }
                 else
                     v = +t;
                 if (label == null)
                     label = axis.tickFormatter(v, axis);
                 if (!isNaN(v))
-                    axis.ticks.push({ v: v, label: label });
+                    axis.ticks.push({ v: v, label: label, showGrid: showGrid });
             }
         }
 
@@ -2079,6 +2082,11 @@ Licensed under the MIT license.
 
                 ctx.beginPath();
                 for (i = 0; i < axis.ticks.length; ++i) {
+                    // Skip entries where showGrid is false
+                    var showGrid = axis.ticks[i].showGrid;
+                    if (showGrid === false)
+                        continue;
+
                     var v = axis.ticks[i].v;
 
                     xoff = yoff = 0;


### PR DESCRIPTION
Sometimes it is nice to have the label show up, but not have it display a grid line. For example, if you want a label to appear between two grid lines, as in the months of the year where the grid lines correspond to the boundaries between months and the month name is right in the middle.

See http://imgur.com/brQFSAX for what I mean.
