### PR TITLE
Add support for drawing axis inside the plot area

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -38,21 +38,21 @@ Licensed under the MIT license.
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 
-    // A shim to provide 'detach' to jQuery versions prior to 1.4.  Using a DOM
-    // operation produces the same effect as detach, i.e. removing the element
-    // without touching its jQuery data.
+	// A shim to provide 'detach' to jQuery versions prior to 1.4.  Using a DOM
+	// operation produces the same effect as detach, i.e. removing the element
+	// without touching its jQuery data.
 
-    // Do not merge this into Flot 0.9, since it requires jQuery 1.4.4+.
+	// Do not merge this into Flot 0.9, since it requires jQuery 1.4.4+.
 
-    if (!$.fn.detach) {
-        $.fn.detach = function() {
-            return this.each(function() {
-                if (this.parentNode) {
-                    this.parentNode.removeChild( this );
-                }
-            });
-        };
-    }
+	if (!$.fn.detach) {
+		$.fn.detach = function() {
+			return this.each(function() {
+				if (this.parentNode) {
+					this.parentNode.removeChild( this );
+				}
+			});
+		};
+	}
 
 	///////////////////////////////////////////////////////////////////////////
 	// The Canvas object is a wrapper around an HTML5 <canvas> tag.
@@ -450,7 +450,7 @@ Licensed under the MIT license.
 		position.element.css({
 			top: Math.round(y),
 			left: Math.round(x),
-			'text-align': halign	// In case the text wraps
+			'text-align': halign    // In case the text wraps
 		});
 	};
 
@@ -505,1258 +505,1277 @@ Licensed under the MIT license.
 	///////////////////////////////////////////////////////////////////////////
 	// The top-level container for the entire plot.
 
-    function Plot(placeholder, data_, options_, plugins) {
-        // data is on the form:
-        //   [ series1, series2 ... ]
-        // where series is either just the data as [ [x1, y1], [x2, y2], ... ]
-        // or { data: [ [x1, y1], [x2, y2], ... ], label: "some label", ... }
-
-        var series = [],
-            options = {
-                // the color theme used for graphs
-                colors: ["#edc240", "#afd8f8", "#cb4b4b", "#4da74d", "#9440ed"],
-                legend: {
-                    show: true,
-                    noColumns: 1, // number of colums in legend table
-                    labelFormatter: null, // fn: string -> string
-                    labelBoxBorderColor: "#ccc", // border color for the little label boxes
-                    container: null, // container (as jQuery object) to put legend in, null means default on top of graph
-                    position: "ne", // position of default legend container within plot
-                    margin: 5, // distance from grid edge to default legend container within plot
-                    backgroundColor: null, // null means auto-detect
-                    backgroundOpacity: 0.85, // set to 0 to avoid background
-                    sorted: null    // default to no legend sorting
-                },
-                xaxis: {
-                    show: null, // null = auto-detect, true = always, false = never
-                    position: "bottom", // or "top"
-                    mode: null, // null or "time"
-                    font: null, // null (derived from CSS in placeholder) or object like { size: 11, lineHeight: 13, style: "italic", weight: "bold", family: "sans-serif", variant: "small-caps" }
-                    color: null, // base color, labels, ticks
-                    tickColor: null, // possibly different color of ticks, e.g. "rgba(0,0,0,0.15)"
-                    transform: null, // null or f: number -> number to transform axis
-                    inverseTransform: null, // if transform is set, this should be the inverse function
-                    min: null, // min. value to show, null means set automatically
-                    max: null, // max. value to show, null means set automatically
-                    autoscaleMargin: null, // margin in % to add if auto-setting min/max
-                    ticks: null, // either [1, 3] or [[1, "a"], 3] or (fn: axis info -> ticks) or app. number of ticks for auto-ticks
-                    tickFormatter: null, // fn: number -> string
-                    labelWidth: null, // size of tick labels in pixels
-                    labelHeight: null,
-                    reserveSpace: null, // whether to reserve space even if axis isn't shown
-                    tickLength: null, // size in pixels of ticks, or "full" for whole line
-                    alignTicksWithAxis: null, // axis number or null for no sync
-                    tickDecimals: null, // no. of decimals, null means auto
-                    tickSize: null, // number or [number, "unit"]
-                    minTickSize: null // number or [number, "unit"]
-                },
-                yaxis: {
-                    autoscaleMargin: 0.02,
-                    position: "left" // or "right"
-                },
-                xaxes: [],
-                yaxes: [],
-                series: {
-                    points: {
-                        show: false,
-                        radius: 3,
-                        lineWidth: 2, // in pixels
-                        fill: true,
-                        fillColor: "#ffffff",
-                        symbol: "circle" // or callback
-                    },
-                    lines: {
-                        // we don't put in show: false so we can see
-                        // whether lines were actively disabled
-                        lineWidth: 2, // in pixels
-                        fill: false,
-                        fillColor: null,
-                        steps: false
-                        // Omit 'zero', so we can later default its value to
-                        // match that of the 'fill' option.
-                    },
-                    bars: {
-                        show: false,
-                        lineWidth: 2, // in pixels
-                        barWidth: 1, // in units of the x axis
-                        fill: true,
-                        fillColor: null,
-                        align: "left", // "left", "right", or "center"
-                        horizontal: false,
-                        zero: true
-                    },
-                    shadowSize: 3,
-                    highlightColor: null
-                },
-                grid: {
-                    show: true,
-                    aboveData: false,
-                    color: "#545454", // primary color used for outline and labels
-                    backgroundColor: null, // null for transparent, else color
-                    borderColor: null, // set if different from the grid color
-                    tickColor: null, // color for the ticks, e.g. "rgba(0,0,0,0.15)"
-                    margin: 0, // distance from the canvas edge to the grid
-                    labelMargin: 5, // in pixels
-                    axisMargin: 8, // in pixels
-                    borderWidth: 2, // in pixels
-                    minBorderMargin: null, // in pixels, null means taken from points radius
-                    markings: null, // array of ranges or fn: axes -> array of ranges
-                    markingsColor: "#f4f4f4",
-                    markingsLineWidth: 2,
-                    // interactive stuff
-                    clickable: false,
-                    hoverable: false,
-                    autoHighlight: true, // highlight in case mouse is near
-                    mouseActiveRadius: 10 // how far the mouse can be away to activate an item
-                },
-                interaction: {
-                    redrawOverlayInterval: 1000/60 // time between updates, -1 means in same flow
-                },
-                hooks: {}
-            },
-        surface = null,     // the canvas for the plot itself
-        overlay = null,     // canvas for interactive stuff on top of plot
-        eventHolder = null, // jQuery object that events should be bound to
-        ctx = null, octx = null,
-        xaxes = [], yaxes = [],
-        plotOffset = { left: 0, right: 0, top: 0, bottom: 0},
-        plotWidth = 0, plotHeight = 0,
-        hooks = {
-            processOptions: [],
-            processRawData: [],
-            processDatapoints: [],
-            processOffset: [],
-            drawBackground: [],
-            drawSeries: [],
-            draw: [],
-            bindEvents: [],
-            drawOverlay: [],
-            shutdown: []
-        },
-        plot = this;
-
-        // public functions
-        plot.setData = setData;
-        plot.setupGrid = setupGrid;
-        plot.draw = draw;
-        plot.getPlaceholder = function() { return placeholder; };
-        plot.getCanvas = function() { return surface.element; };
-        plot.getPlotOffset = function() { return plotOffset; };
-        plot.width = function () { return plotWidth; };
-        plot.height = function () { return plotHeight; };
-        plot.offset = function () {
-            var o = eventHolder.offset();
-            o.left += plotOffset.left;
-            o.top += plotOffset.top;
-            return o;
-        };
-        plot.getData = function () { return series; };
-        plot.getAxes = function () {
-            var res = {}, i;
-            $.each(xaxes.concat(yaxes), function (_, axis) {
-                if (axis)
-                    res[axis.direction + (axis.n != 1 ? axis.n : "") + "axis"] = axis;
-            });
-            return res;
-        };
-        plot.getXAxes = function () { return xaxes; };
-        plot.getYAxes = function () { return yaxes; };
-        plot.c2p = canvasToAxisCoords;
-        plot.p2c = axisToCanvasCoords;
-        plot.getOptions = function () { return options; };
-        plot.highlight = highlight;
-        plot.unhighlight = unhighlight;
-        plot.triggerRedrawOverlay = triggerRedrawOverlay;
-        plot.pointOffset = function(point) {
-            return {
-                left: parseInt(xaxes[axisNumber(point, "x") - 1].p2c(+point.x) + plotOffset.left, 10),
-                top: parseInt(yaxes[axisNumber(point, "y") - 1].p2c(+point.y) + plotOffset.top, 10)
-            };
-        };
-        plot.shutdown = shutdown;
-        plot.destroy = function () {
-            shutdown();
-            placeholder.removeData("plot").empty();
-
-            series = [];
-            options = null;
-            surface = null;
-            overlay = null;
-            eventHolder = null;
-            ctx = null;
-            octx = null;
-            xaxes = [];
-            yaxes = [];
-            hooks = null;
-            highlights = [];
-            plot = null;
-        };
-        plot.resize = function () {
-        	var width = placeholder.width(),
-        		height = placeholder.height();
-            surface.resize(width, height);
-            overlay.resize(width, height);
-        };
-
-        // public attributes
-        plot.hooks = hooks;
-
-        // initialize
-        initPlugins(plot);
-        parseOptions(options_);
-        setupCanvases();
-        setData(data_);
-        setupGrid();
-        draw();
-        bindEvents();
-
-
-        function executeHooks(hook, args) {
-            args = [plot].concat(args);
-            for (var i = 0; i < hook.length; ++i)
-                hook[i].apply(this, args);
-        }
-
-        function initPlugins() {
-
-            // References to key classes, allowing plugins to modify them
-
-            var classes = {
-                Canvas: Canvas
-            };
-
-            for (var i = 0; i < plugins.length; ++i) {
-                var p = plugins[i];
-                p.init(plot, classes);
-                if (p.options)
-                    $.extend(true, options, p.options);
-            }
-        }
-
-        function parseOptions(opts) {
-
-            $.extend(true, options, opts);
-
-            // $.extend merges arrays, rather than replacing them.  When less
-            // colors are provided than the size of the default palette, we
-            // end up with those colors plus the remaining defaults, which is
-            // not expected behavior; avoid it by replacing them here.
-
-            if (opts && opts.colors) {
-            	options.colors = opts.colors;
-            }
-
-            if (options.xaxis.color == null)
-                options.xaxis.color = $.color.parse(options.grid.color).scale('a', 0.22).toString();
-            if (options.yaxis.color == null)
-                options.yaxis.color = $.color.parse(options.grid.color).scale('a', 0.22).toString();
-
-            if (options.xaxis.tickColor == null) // grid.tickColor for back-compatibility
-                options.xaxis.tickColor = options.grid.tickColor || options.xaxis.color;
-            if (options.yaxis.tickColor == null) // grid.tickColor for back-compatibility
-                options.yaxis.tickColor = options.grid.tickColor || options.yaxis.color;
-
-            if (options.grid.borderColor == null)
-                options.grid.borderColor = options.grid.color;
-            if (options.grid.tickColor == null)
-                options.grid.tickColor = $.color.parse(options.grid.color).scale('a', 0.22).toString();
-
-            // Fill in defaults for axis options, including any unspecified
-            // font-spec fields, if a font-spec was provided.
-
-            // If no x/y axis options were provided, create one of each anyway,
-            // since the rest of the code assumes that they exist.
-
-            var i, axisOptions, axisCount,
-                fontSize = placeholder.css("font-size"),
-                fontSizeDefault = fontSize ? +fontSize.replace("px", "") : 13,
-                fontDefaults = {
-                    style: placeholder.css("font-style"),
-                    size: Math.round(0.8 * fontSizeDefault),
-                    variant: placeholder.css("font-variant"),
-                    weight: placeholder.css("font-weight"),
-                    family: placeholder.css("font-family")
-                };
-
-            axisCount = options.xaxes.length || 1;
-            for (i = 0; i < axisCount; ++i) {
-
-                axisOptions = options.xaxes[i];
-                if (axisOptions && !axisOptions.tickColor) {
-                    axisOptions.tickColor = axisOptions.color;
-                }
-
-                axisOptions = $.extend(true, {}, options.xaxis, axisOptions);
-                options.xaxes[i] = axisOptions;
-
-                if (axisOptions.font) {
-                    axisOptions.font = $.extend({}, fontDefaults, axisOptions.font);
-                    if (!axisOptions.font.color) {
-                        axisOptions.font.color = axisOptions.color;
-                    }
-                    if (!axisOptions.font.lineHeight) {
-                        axisOptions.font.lineHeight = Math.round(axisOptions.font.size * 1.15);
-                    }
-                }
-            }
-
-            axisCount = options.yaxes.length || 1;
-            for (i = 0; i < axisCount; ++i) {
-
-                axisOptions = options.yaxes[i];
-                if (axisOptions && !axisOptions.tickColor) {
-                    axisOptions.tickColor = axisOptions.color;
-                }
-
-                axisOptions = $.extend(true, {}, options.yaxis, axisOptions);
-                options.yaxes[i] = axisOptions;
-
-                if (axisOptions.font) {
-                    axisOptions.font = $.extend({}, fontDefaults, axisOptions.font);
-                    if (!axisOptions.font.color) {
-                        axisOptions.font.color = axisOptions.color;
-                    }
-                    if (!axisOptions.font.lineHeight) {
-                        axisOptions.font.lineHeight = Math.round(axisOptions.font.size * 1.15);
-                    }
-                }
-            }
-
-            // backwards compatibility, to be removed in future
-            if (options.xaxis.noTicks && options.xaxis.ticks == null)
-                options.xaxis.ticks = options.xaxis.noTicks;
-            if (options.yaxis.noTicks && options.yaxis.ticks == null)
-                options.yaxis.ticks = options.yaxis.noTicks;
-            if (options.x2axis) {
-                options.xaxes[1] = $.extend(true, {}, options.xaxis, options.x2axis);
-                options.xaxes[1].position = "top";
-                // Override the inherit to allow the axis to auto-scale
-                if (options.x2axis.min == null) {
-                    options.xaxes[1].min = null;
-                }
-                if (options.x2axis.max == null) {
-                    options.xaxes[1].max = null;
-                }
-            }
-            if (options.y2axis) {
-                options.yaxes[1] = $.extend(true, {}, options.yaxis, options.y2axis);
-                options.yaxes[1].position = "right";
-                // Override the inherit to allow the axis to auto-scale
-                if (options.y2axis.min == null) {
-                    options.yaxes[1].min = null;
-                }
-                if (options.y2axis.max == null) {
-                    options.yaxes[1].max = null;
-                }
-            }
-            if (options.grid.coloredAreas)
-                options.grid.markings = options.grid.coloredAreas;
-            if (options.grid.coloredAreasColor)
-                options.grid.markingsColor = options.grid.coloredAreasColor;
-            if (options.lines)
-                $.extend(true, options.series.lines, options.lines);
-            if (options.points)
-                $.extend(true, options.series.points, options.points);
-            if (options.bars)
-                $.extend(true, options.series.bars, options.bars);
-            if (options.shadowSize != null)
-                options.series.shadowSize = options.shadowSize;
-            if (options.highlightColor != null)
-                options.series.highlightColor = options.highlightColor;
-
-            // save options on axes for future reference
-            for (i = 0; i < options.xaxes.length; ++i)
-                getOrCreateAxis(xaxes, i + 1).options = options.xaxes[i];
-            for (i = 0; i < options.yaxes.length; ++i)
-                getOrCreateAxis(yaxes, i + 1).options = options.yaxes[i];
-
-            // add hooks from options
-            for (var n in hooks)
-                if (options.hooks[n] && options.hooks[n].length)
-                    hooks[n] = hooks[n].concat(options.hooks[n]);
-
-            executeHooks(hooks.processOptions, [options]);
-        }
-
-        function setData(d) {
-            series = parseData(d);
-            fillInSeriesOptions();
-            processData();
-        }
-
-        function parseData(d) {
-            var res = [];
-            for (var i = 0; i < d.length; ++i) {
-                var s = $.extend(true, {}, options.series);
-
-                if (d[i].data != null) {
-                    s.data = d[i].data; // move the data instead of deep-copy
-                    delete d[i].data;
-
-                    $.extend(true, s, d[i]);
-
-                    d[i].data = s.data;
-                }
-                else
-                    s.data = d[i];
-                res.push(s);
-            }
-
-            return res;
-        }
-
-        function axisNumber(obj, coord) {
-            var a = obj[coord + "axis"];
-            if (typeof a == "object") // if we got a real axis, extract number
-                a = a.n;
-            if (typeof a != "number")
-                a = 1; // default to first axis
-            return a;
-        }
-
-        function allAxes() {
-            // return flat array without annoying null entries
-            return $.grep(xaxes.concat(yaxes), function (a) { return a; });
-        }
-
-        function canvasToAxisCoords(pos) {
-            // return an object with x/y corresponding to all used axes
-            var res = {}, i, axis;
-            for (i = 0; i < xaxes.length; ++i) {
-                axis = xaxes[i];
-                if (axis && axis.used)
-                    res["x" + axis.n] = axis.c2p(pos.left);
-            }
-
-            for (i = 0; i < yaxes.length; ++i) {
-                axis = yaxes[i];
-                if (axis && axis.used)
-                    res["y" + axis.n] = axis.c2p(pos.top);
-            }
-
-            if (res.x1 !== undefined)
-                res.x = res.x1;
-            if (res.y1 !== undefined)
-                res.y = res.y1;
-
-            return res;
-        }
-
-        function axisToCanvasCoords(pos) {
-            // get canvas coords from the first pair of x/y found in pos
-            var res = {}, i, axis, key;
-
-            for (i = 0; i < xaxes.length; ++i) {
-                axis = xaxes[i];
-                if (axis && axis.used) {
-                    key = "x" + axis.n;
-                    if (pos[key] == null && axis.n == 1)
-                        key = "x";
-
-                    if (pos[key] != null) {
-                        res.left = axis.p2c(pos[key]);
-                        break;
-                    }
-                }
-            }
-
-            for (i = 0; i < yaxes.length; ++i) {
-                axis = yaxes[i];
-                if (axis && axis.used) {
-                    key = "y" + axis.n;
-                    if (pos[key] == null && axis.n == 1)
-                        key = "y";
-
-                    if (pos[key] != null) {
-                        res.top = axis.p2c(pos[key]);
-                        break;
-                    }
-                }
-            }
-
-            return res;
-        }
-
-        function getOrCreateAxis(axes, number) {
-            if (!axes[number - 1])
-                axes[number - 1] = {
-                    n: number, // save the number for future reference
-                    direction: axes == xaxes ? "x" : "y",
-                    options: $.extend(true, {}, axes == xaxes ? options.xaxis : options.yaxis)
-                };
-
-            return axes[number - 1];
-        }
-
-        function fillInSeriesOptions() {
-
-            var neededColors = series.length, maxIndex = -1, i;
-
-            // Subtract the number of series that already have fixed colors or
-            // color indexes from the number that we still need to generate.
-
-            for (i = 0; i < series.length; ++i) {
-                var sc = series[i].color;
-                if (sc != null) {
-                    neededColors--;
-                    if (typeof sc == "number" && sc > maxIndex) {
-                        maxIndex = sc;
-                    }
-                }
-            }
-
-            // If any of the series have fixed color indexes, then we need to
-            // generate at least as many colors as the highest index.
-
-            if (neededColors <= maxIndex) {
-                neededColors = maxIndex + 1;
-            }
-
-            // Generate all the colors, using first the option colors and then
-            // variations on those colors once they're exhausted.
-
-            var c, colors = [], colorPool = options.colors,
-                colorPoolSize = colorPool.length, variation = 0;
-
-            for (i = 0; i < neededColors; i++) {
-
-                c = $.color.parse(colorPool[i % colorPoolSize] || "#666");
-
-                // Each time we exhaust the colors in the pool we adjust
-                // a scaling factor used to produce more variations on
-                // those colors. The factor alternates negative/positive
-                // to produce lighter/darker colors.
-
-                // Reset the variation after every few cycles, or else
-                // it will end up producing only white or black colors.
-
-                if (i % colorPoolSize == 0 && i) {
-                    if (variation >= 0) {
-                        if (variation < 0.5) {
-                            variation = -variation - 0.2;
-                        } else variation = 0;
-                    } else variation = -variation;
-                }
-
-                colors[i] = c.scale('rgb', 1 + variation);
-            }
-
-            // Finalize the series options, filling in their colors
-
-            var colori = 0, s;
-            for (i = 0; i < series.length; ++i) {
-                s = series[i];
-
-                // assign colors
-                if (s.color == null) {
-                    s.color = colors[colori].toString();
-                    ++colori;
-                }
-                else if (typeof s.color == "number")
-                    s.color = colors[s.color].toString();
-
-                // turn on lines automatically in case nothing is set
-                if (s.lines.show == null) {
-                    var v, show = true;
-                    for (v in s)
-                        if (s[v] && s[v].show) {
-                            show = false;
-                            break;
-                        }
-                    if (show)
-                        s.lines.show = true;
-                }
-
-                // If nothing was provided for lines.zero, default it to match
-                // lines.fill, since areas by default should extend to zero.
-
-                if (s.lines.zero == null) {
-                    s.lines.zero = !!s.lines.fill;
-                }
-
-                // setup axes
-                s.xaxis = getOrCreateAxis(xaxes, axisNumber(s, "x"));
-                s.yaxis = getOrCreateAxis(yaxes, axisNumber(s, "y"));
-            }
-        }
-
-        function processData() {
-            var topSentry = Number.POSITIVE_INFINITY,
-                bottomSentry = Number.NEGATIVE_INFINITY,
-                fakeInfinity = Number.MAX_VALUE,
-                i, j, k, m, length,
-                s, points, ps, x, y, axis, val, f, p,
-                data, format;
-
-            function updateAxis(axis, min, max) {
-                if (min < axis.datamin && min != -fakeInfinity)
-                    axis.datamin = min;
-                if (max > axis.datamax && max != fakeInfinity)
-                    axis.datamax = max;
-            }
-
-            $.each(allAxes(), function (_, axis) {
-                // init axis
-                axis.datamin = topSentry;
-                axis.datamax = bottomSentry;
-                axis.used = false;
-            });
-
-            for (i = 0; i < series.length; ++i) {
-                s = series[i];
-                s.datapoints = { points: [] };
-
-                executeHooks(hooks.processRawData, [ s, s.data, s.datapoints ]);
-            }
-
-            // first pass: clean and copy data
-            for (i = 0; i < series.length; ++i) {
-                s = series[i];
-
-                data = s.data;
-                format = s.datapoints.format;
-
-                if (!format) {
-                    format = [];
-                    // find out how to copy
-                    format.push({ x: true, number: true, required: true });
-                    format.push({ y: true, number: true, required: true });
-
-                    if (s.bars.show || (s.lines.show && s.lines.fill)) {
-                        var autoscale = !!((s.bars.show && s.bars.zero) || (s.lines.show && s.lines.zero));
-                        format.push({ y: true, number: true, required: false, defaultValue: 0, autoscale: autoscale });
-                        if (s.bars.horizontal) {
-                            delete format[format.length - 1].y;
-                            format[format.length - 1].x = true;
-                        }
-                    }
-
-                    s.datapoints.format = format;
-                }
-
-                if (s.datapoints.pointsize != null)
-                    continue; // already filled in
-
-                s.datapoints.pointsize = format.length;
-
-                ps = s.datapoints.pointsize;
-                points = s.datapoints.points;
-
-                var insertSteps = s.lines.show && s.lines.steps;
-                s.xaxis.used = s.yaxis.used = true;
-
-                for (j = k = 0; j < data.length; ++j, k += ps) {
-                    p = data[j];
-
-                    var nullify = p == null;
-                    if (!nullify) {
-                        for (m = 0; m < ps; ++m) {
-                            val = p[m];
-                            f = format[m];
-
-                            if (f) {
-                                if (f.number && val != null) {
-                                    val = +val; // convert to number
-                                    if (isNaN(val))
-                                        val = null;
-                                    else if (val == Infinity)
-                                        val = fakeInfinity;
-                                    else if (val == -Infinity)
-                                        val = -fakeInfinity;
-                                }
-
-                                if (val == null) {
-                                    if (f.required)
-                                        nullify = true;
-
-                                    if (f.defaultValue != null)
-                                        val = f.defaultValue;
-                                }
-                            }
-
-                            points[k + m] = val;
-                        }
-                    }
-
-                    if (nullify) {
-                        for (m = 0; m < ps; ++m) {
-                            val = points[k + m];
-                            if (val != null) {
-                                f = format[m];
-                                // extract min/max info
-                                if (f.autoscale !== false) {
-                                    if (f.x) {
-                                        updateAxis(s.xaxis, val, val);
-                                    }
-                                    if (f.y) {
-                                        updateAxis(s.yaxis, val, val);
-                                    }
-                                }
-                            }
-                            points[k + m] = null;
-                        }
-                    }
-                    else {
-                        // a little bit of line specific stuff that
-                        // perhaps shouldn't be here, but lacking
-                        // better means...
-                        if (insertSteps && k > 0
-                            && points[k - ps] != null
-                            && points[k - ps] != points[k]
-                            && points[k - ps + 1] != points[k + 1]) {
-                            // copy the point to make room for a middle point
-                            for (m = 0; m < ps; ++m)
-                                points[k + ps + m] = points[k + m];
-
-                            // middle point has same y
-                            points[k + 1] = points[k - ps + 1];
-
-                            // we've added a point, better reflect that
-                            k += ps;
-                        }
-                    }
-                }
-            }
-
-            // give the hooks a chance to run
-            for (i = 0; i < series.length; ++i) {
-                s = series[i];
-
-                executeHooks(hooks.processDatapoints, [ s, s.datapoints]);
-            }
-
-            // second pass: find datamax/datamin for auto-scaling
-            for (i = 0; i < series.length; ++i) {
-                s = series[i];
-                points = s.datapoints.points;
-                ps = s.datapoints.pointsize;
-                format = s.datapoints.format;
-
-                var xmin = topSentry, ymin = topSentry,
-                    xmax = bottomSentry, ymax = bottomSentry;
-
-                for (j = 0; j < points.length; j += ps) {
-                    if (points[j] == null)
-                        continue;
-
-                    for (m = 0; m < ps; ++m) {
-                        val = points[j + m];
-                        f = format[m];
-                        if (!f || f.autoscale === false || val == fakeInfinity || val == -fakeInfinity)
-                            continue;
-
-                        if (f.x) {
-                            if (val < xmin)
-                                xmin = val;
-                            if (val > xmax)
-                                xmax = val;
-                        }
-                        if (f.y) {
-                            if (val < ymin)
-                                ymin = val;
-                            if (val > ymax)
-                                ymax = val;
-                        }
-                    }
-                }
-
-                if (s.bars.show) {
-                    // make sure we got room for the bar on the dancing floor
-                    var delta;
-
-                    switch (s.bars.align) {
-                        case "left":
-                            delta = 0;
-                            break;
-                        case "right":
-                            delta = -s.bars.barWidth;
-                            break;
-                        default:
-                            delta = -s.bars.barWidth / 2;
-                    }
-
-                    if (s.bars.horizontal) {
-                        ymin += delta;
-                        ymax += delta + s.bars.barWidth;
-                    }
-                    else {
-                        xmin += delta;
-                        xmax += delta + s.bars.barWidth;
-                    }
-                }
-
-                updateAxis(s.xaxis, xmin, xmax);
-                updateAxis(s.yaxis, ymin, ymax);
-            }
-
-            $.each(allAxes(), function (_, axis) {
-                if (axis.datamin == topSentry)
-                    axis.datamin = null;
-                if (axis.datamax == bottomSentry)
-                    axis.datamax = null;
-            });
-        }
-
-        function setupCanvases() {
-
-            // Make sure the placeholder is clear of everything except canvases
-            // from a previous plot in this container that we'll try to re-use.
-
-            placeholder.css("padding", 0) // padding messes up the positioning
-                .children().filter(function(){
-                    return !$(this).hasClass("flot-overlay") && !$(this).hasClass('flot-base');
-                }).remove();
-
-            if (placeholder.css("position") == 'static')
-                placeholder.css("position", "relative"); // for positioning labels and overlay
-
-            surface = new Canvas("flot-base", placeholder);
-            overlay = new Canvas("flot-overlay", placeholder); // overlay canvas for interactive features
-
-            ctx = surface.context;
-            octx = overlay.context;
-
-            // define which element we're listening for events on
-            eventHolder = $(overlay.element).unbind();
-
-            // If we're re-using a plot object, shut down the old one
-
-            var existing = placeholder.data("plot");
-
-            if (existing) {
-                existing.shutdown();
-                overlay.clear();
-            }
-
-            // save in case we get replotted
-            placeholder.data("plot", plot);
-        }
-
-        function bindEvents() {
-            // bind events
-            if (options.grid.hoverable) {
-                eventHolder.mousemove(onMouseMove);
-
-                // Use bind, rather than .mouseleave, because we officially
-                // still support jQuery 1.2.6, which doesn't define a shortcut
-                // for mouseenter or mouseleave.  This was a bug/oversight that
-                // was fixed somewhere around 1.3.x.  We can return to using
-                // .mouseleave when we drop support for 1.2.6.
-
-                eventHolder.bind("mouseleave", onMouseLeave);
-            }
-
-            if (options.grid.clickable)
-                eventHolder.click(onClick);
-
-            executeHooks(hooks.bindEvents, [eventHolder]);
-        }
-
-        function shutdown() {
-            if (redrawTimeout)
-                clearTimeout(redrawTimeout);
-
-            eventHolder.unbind("mousemove", onMouseMove);
-            eventHolder.unbind("mouseleave", onMouseLeave);
-            eventHolder.unbind("click", onClick);
-
-            executeHooks(hooks.shutdown, [eventHolder]);
-        }
-
-        function setTransformationHelpers(axis) {
-            // set helper functions on the axis, assumes plot area
-            // has been computed already
-
-            function identity(x) { return x; }
-
-            var s, m, t = axis.options.transform || identity,
-                it = axis.options.inverseTransform;
-
-            // precompute how much the axis is scaling a point
-            // in canvas space
-            if (axis.direction == "x") {
-                s = axis.scale = plotWidth / Math.abs(t(axis.max) - t(axis.min));
-                m = Math.min(t(axis.max), t(axis.min));
-            }
-            else {
-                s = axis.scale = plotHeight / Math.abs(t(axis.max) - t(axis.min));
-                s = -s;
-                m = Math.max(t(axis.max), t(axis.min));
-            }
-
-            // data point to canvas coordinate
-            if (t == identity) // slight optimization
-                axis.p2c = function (p) { return (p - m) * s; };
-            else
-                axis.p2c = function (p) { return (t(p) - m) * s; };
-            // canvas coordinate to data point
-            if (!it)
-                axis.c2p = function (c) { return m + c / s; };
-            else
-                axis.c2p = function (c) { return it(m + c / s); };
-        }
-
-        function measureTickLabels(axis) {
-
-            var opts = axis.options,
-                ticks = axis.ticks || [],
-                labelWidth = opts.labelWidth || 0,
-                labelHeight = opts.labelHeight || 0,
-                maxWidth = labelWidth || (axis.direction == "x" ? Math.floor(surface.width / (ticks.length || 1)) : null),
-                legacyStyles = axis.direction + "Axis " + axis.direction + axis.n + "Axis",
-                layer = "flot-" + axis.direction + "-axis flot-" + axis.direction + axis.n + "-axis " + legacyStyles,
-                font = opts.font || "flot-tick-label tickLabel";
-
-            for (var i = 0; i < ticks.length; ++i) {
-
-                var t = ticks[i];
-
-                if (!t.label)
-                    continue;
-
-                var info = surface.getTextInfo(layer, t.label, font, null, maxWidth);
-
-                labelWidth = Math.max(labelWidth, info.width);
-                labelHeight = Math.max(labelHeight, info.height);
-            }
-
-            axis.labelWidth = opts.labelWidth || labelWidth;
-            axis.labelHeight = opts.labelHeight || labelHeight;
-        }
-
-        function allocateAxisBoxFirstPhase(axis) {
-            // find the bounding box of the axis by looking at label
-            // widths/heights and ticks, make room by diminishing the
-            // plotOffset; this first phase only looks at one
-            // dimension per axis, the other dimension depends on the
-            // other axes so will have to wait
-
-            var lw = axis.labelWidth,
-                lh = axis.labelHeight,
-                pos = axis.options.position,
-                isXAxis = axis.direction === "x",
-                tickLength = axis.options.tickLength,
-                axisMargin = options.grid.axisMargin,
-                padding = options.grid.labelMargin,
-                innermost = true,
-                outermost = true,
-                first = true,
-                found = false;
-
-            // Determine the axis's position in its direction and on its side
-
-            $.each(isXAxis ? xaxes : yaxes, function(i, a) {
-                if (a && (a.show || a.reserveSpace)) {
-                    if (a === axis) {
-                        found = true;
-                    } else if (a.options.position === pos) {
-                        if (found) {
-                            outermost = false;
-                        } else {
-                            innermost = false;
-                        }
-                    }
-                    if (!found) {
-                        first = false;
-                    }
-                }
-            });
-
-            // The outermost axis on each side has no margin
-
-            if (outermost) {
-                axisMargin = 0;
-            }
-
-            // The ticks for the first axis in each direction stretch across
-
-            if (tickLength == null) {
-                tickLength = first ? "full" : 5;
-            }
-
-            if (!isNaN(+tickLength))
-                padding += +tickLength;
-
-            if (isXAxis) {
-                lh += padding;
-
-                if (pos == "bottom") {
-                    plotOffset.bottom += lh + axisMargin;
-                    axis.box = { top: surface.height - plotOffset.bottom, height: lh };
-                }
-                else {
-                    axis.box = { top: plotOffset.top + axisMargin, height: lh };
-                    plotOffset.top += lh + axisMargin;
-                }
-            }
-            else {
-                lw += padding;
-
-                if (pos == "left") {
-                    axis.box = { left: plotOffset.left + axisMargin, width: lw };
-                    plotOffset.left += lw + axisMargin;
-                }
-                else {
-                    plotOffset.right += lw + axisMargin;
-                    axis.box = { left: surface.width - plotOffset.right, width: lw };
-                }
-            }
-
-             // save for future reference
-            axis.position = pos;
-            axis.tickLength = tickLength;
-            axis.box.padding = padding;
-            axis.innermost = innermost;
-        }
-
-        function allocateAxisBoxSecondPhase(axis) {
-            // now that all axis boxes have been placed in one
-            // dimension, we can set the remaining dimension coordinates
-            if (axis.direction == "x") {
-                axis.box.left = plotOffset.left - axis.labelWidth / 2;
-                axis.box.width = surface.width - plotOffset.left - plotOffset.right + axis.labelWidth;
-            }
-            else {
-                axis.box.top = plotOffset.top - axis.labelHeight / 2;
-                axis.box.height = surface.height - plotOffset.bottom - plotOffset.top + axis.labelHeight;
-            }
-        }
-
-        function adjustLayoutForThingsStickingOut() {
-            // possibly adjust plot offset to ensure everything stays
-            // inside the canvas and isn't clipped off
-
-            var minMargin = options.grid.minBorderMargin,
-                axis, i;
-
-            // check stuff from the plot (FIXME: this should just read
-            // a value from the series, otherwise it's impossible to
-            // customize)
-            if (minMargin == null) {
-                minMargin = 0;
-                for (i = 0; i < series.length; ++i)
-                    minMargin = Math.max(minMargin, 2 * (series[i].points.radius + series[i].points.lineWidth/2));
-            }
-
-            var margins = {
-                left: minMargin,
-                right: minMargin,
-                top: minMargin,
-                bottom: minMargin
-            };
-
-            // check axis labels, note we don't check the actual
-            // labels but instead use the overall width/height to not
-            // jump as much around with replots
-            $.each(allAxes(), function (_, axis) {
-                if (axis.reserveSpace && axis.ticks && axis.ticks.length) {
-                    if (axis.direction === "x") {
-                        margins.left = Math.max(margins.left, axis.labelWidth / 2);
-                        margins.right = Math.max(margins.right, axis.labelWidth / 2);
-                    } else {
-                        margins.bottom = Math.max(margins.bottom, axis.labelHeight / 2);
-                        margins.top = Math.max(margins.top, axis.labelHeight / 2);
-                    }
-                }
-            });
-
-            plotOffset.left = Math.ceil(Math.max(margins.left, plotOffset.left));
-            plotOffset.right = Math.ceil(Math.max(margins.right, plotOffset.right));
-            plotOffset.top = Math.ceil(Math.max(margins.top, plotOffset.top));
-            plotOffset.bottom = Math.ceil(Math.max(margins.bottom, plotOffset.bottom));
-        }
-
-        function setupGrid() {
-            var i, axes = allAxes(), showGrid = options.grid.show;
-
-            // Initialize the plot's offset from the edge of the canvas
-
-            for (var a in plotOffset) {
-                var margin = options.grid.margin || 0;
-                plotOffset[a] = typeof margin == "number" ? margin : margin[a] || 0;
-            }
-
-            executeHooks(hooks.processOffset, [plotOffset]);
-
-            // If the grid is visible, add its border width to the offset
-
-            for (var a in plotOffset) {
-                if(typeof(options.grid.borderWidth) == "object") {
-                    plotOffset[a] += showGrid ? options.grid.borderWidth[a] : 0;
-                }
-                else {
-                    plotOffset[a] += showGrid ? options.grid.borderWidth : 0;
-                }
-            }
-
-            $.each(axes, function (_, axis) {
-                var axisOpts = axis.options;
-                axis.show = axisOpts.show == null ? axis.used : axisOpts.show;
-                axis.reserveSpace = axisOpts.reserveSpace == null ? axis.show : axisOpts.reserveSpace;
-                setRange(axis);
-            });
-
-            if (showGrid) {
-
-                var allocatedAxes = $.grep(axes, function (axis) {
-                    return axis.show || axis.reserveSpace;
-                });
-
-                $.each(allocatedAxes, function (_, axis) {
-                    // make the ticks
-                    setupTickGeneration(axis);
-                    setTicks(axis);
-                    snapRangeToTicks(axis, axis.ticks);
-                    // find labelWidth/Height for axis
-                    measureTickLabels(axis);
-                });
-
-                // with all dimensions calculated, we can compute the
-                // axis bounding boxes, start from the outside
-                // (reverse order)
-                for (i = allocatedAxes.length - 1; i >= 0; --i)
-                    allocateAxisBoxFirstPhase(allocatedAxes[i]);
-
-                // make sure we've got enough space for things that
-                // might stick out
-                adjustLayoutForThingsStickingOut();
-
-                $.each(allocatedAxes, function (_, axis) {
-                    allocateAxisBoxSecondPhase(axis);
-                });
-            }
-
-            plotWidth = surface.width - plotOffset.left - plotOffset.right;
-            plotHeight = surface.height - plotOffset.bottom - plotOffset.top;
-
-            // now we got the proper plot dimensions, we can compute the scaling
-            $.each(axes, function (_, axis) {
-                setTransformationHelpers(axis);
-            });
-
-            if (showGrid) {
-                drawAxisLabels();
-            }
-
-            insertLegend();
-        }
-
-        function setRange(axis) {
-            var opts = axis.options,
-                min = +(opts.min != null ? opts.min : axis.datamin),
-                max = +(opts.max != null ? opts.max : axis.datamax),
-                delta = max - min;
-
-            if (delta == 0.0) {
-                // degenerate case
-                var widen = max == 0 ? 1 : 0.01;
-
-                if (opts.min == null)
-                    min -= widen;
-                // always widen max if we couldn't widen min to ensure we
-                // don't fall into min == max which doesn't work
-                if (opts.max == null || opts.min != null)
-                    max += widen;
-            }
-            else {
-                // consider autoscaling
-                var margin = opts.autoscaleMargin;
-                if (margin != null) {
-                    if (opts.min == null) {
-                        min -= delta * margin;
-                        // make sure we don't go below zero if all values
-                        // are positive
-                        if (min < 0 && axis.datamin != null && axis.datamin >= 0)
-                            min = 0;
-                    }
-                    if (opts.max == null) {
-                        max += delta * margin;
-                        if (max > 0 && axis.datamax != null && axis.datamax <= 0)
-                            max = 0;
-                    }
-                }
-            }
-            axis.min = min;
-            axis.max = max;
-        }
-
-        function setupTickGeneration(axis) {
-            var opts = axis.options;
-
-            // estimate number of ticks
-            var noTicks;
-            if (typeof opts.ticks == "number" && opts.ticks > 0)
-                noTicks = opts.ticks;
-            else
-                // heuristic based on the model a*sqrt(x) fitted to
-                // some data points that seemed reasonable
-                noTicks = 0.3 * Math.sqrt(axis.direction == "x" ? surface.width : surface.height);
-
-            var delta = (axis.max - axis.min) / noTicks,
-                dec = -Math.floor(Math.log(delta) / Math.LN10),
-                maxDec = opts.tickDecimals;
-
-            if (maxDec != null && dec > maxDec) {
-                dec = maxDec;
-            }
-
-            var magn = Math.pow(10, -dec),
-                norm = delta / magn, // norm is between 1.0 and 10.0
-                size;
-
-            if (norm < 1.5) {
-                size = 1;
-            } else if (norm < 3) {
-                size = 2;
-                // special case for 2.5, requires an extra decimal
-                if (norm > 2.25 && (maxDec == null || dec + 1 <= maxDec)) {
-                    size = 2.5;
-                    ++dec;
-                }
-            } else if (norm < 7.5) {
-                size = 5;
-            } else {
-                size = 10;
-            }
-
-            size *= magn;
-
-            if (opts.minTickSize != null && size < opts.minTickSize) {
-                size = opts.minTickSize;
-            }
-
-            axis.delta = delta;
-            axis.tickDecimals = Math.max(0, maxDec != null ? maxDec : dec);
-            axis.tickSize = opts.tickSize || size;
-
-            // Time mode was moved to a plug-in in 0.8, and since so many people use it
-            // we'll add an especially friendly reminder to make sure they included it.
-
-            if (opts.mode == "time" && !axis.tickGenerator) {
-                throw new Error("Time mode requires the flot.time plugin.");
-            }
-
-            // Flot supports base-10 axes; any other mode else is handled by a plug-in,
-            // like flot.time.js.
-
-            if (!axis.tickGenerator) {
-
-                axis.tickGenerator = function (axis) {
-
-                    var ticks = [],
-                        start = floorInBase(axis.min, axis.tickSize),
-                        i = 0,
-                        v = Number.NaN,
-                        prev;
-
-                    do {
-                        prev = v;
-                        v = start + i * axis.tickSize;
-                        ticks.push(v);
-                        ++i;
-                    } while (v < axis.max && v != prev);
-                    return ticks;
-                };
+	function Plot(placeholder, data_, options_, plugins) {
+		// data is on the form:
+		//   [ series1, series2 ... ]
+		// where series is either just the data as [ [x1, y1], [x2, y2], ... ]
+		// or { data: [ [x1, y1], [x2, y2], ... ], label: "some label", ... }
+
+		var series = [],
+			options = {
+				// the color theme used for graphs
+				colors: ["#edc240", "#afd8f8", "#cb4b4b", "#4da74d", "#9440ed"],
+				legend: {
+					show: true,
+					noColumns: 1, // number of colums in legend table
+					labelFormatter: null, // fn: string -> string
+					labelBoxBorderColor: "#ccc", // border color for the little label boxes
+					container: null, // container (as jQuery object) to put legend in, null means default on top of graph
+					position: "ne", // position of default legend container within plot
+					margin: 5, // distance from grid edge to default legend container within plot
+					backgroundColor: null, // null means auto-detect
+					backgroundOpacity: 0.85, // set to 0 to avoid background
+					sorted: null    // default to no legend sorting
+				},
+				xaxis: {
+					show: null, // null = auto-detect, true = always, false = never
+					position: "bottom", // or "top"
+					mode: null, // null or "time"
+					font: null, // null (derived from CSS in placeholder) or object like { size: 11, lineHeight: 13, style: "italic", weight: "bold", family: "sans-serif", variant: "small-caps" }
+					color: null, // base color, labels, ticks
+					tickColor: null, // possibly different color of ticks, e.g. "rgba(0,0,0,0.15)"
+					transform: null, // null or f: number -> number to transform axis
+					inverseTransform: null, // if transform is set, this should be the inverse function
+					min: null, // min. value to show, null means set automatically
+					max: null, // max. value to show, null means set automatically
+					autoscaleMargin: null, // margin in % to add if auto-setting min/max
+					ticks: null, // either [1, 3] or [[1, "a"], 3] or (fn: axis info -> ticks) or app. number of ticks for auto-ticks
+					tickFormatter: null, // fn: number -> string
+					labelWidth: null, // size of tick labels in pixels
+					labelHeight: null,
+					reserveSpace: null, // whether to reserve space even if axis isn't shown
+					tickLength: null, // size in pixels of ticks, or "full" for whole line
+					alignTicksWithAxis: null, // axis number or null for no sync
+					tickDecimals: null, // no. of decimals, null means auto
+					tickSize: null, // number or [number, "unit"]
+					minTickSize: null // number or [number, "unit"]
+				},
+				yaxis: {
+					autoscaleMargin: 0.02,
+					position: "left" // or "right"
+				},
+				xaxes: [],
+				yaxes: [],
+				series: {
+					points: {
+						show: false,
+						radius: 3,
+						lineWidth: 2, // in pixels
+						fill: true,
+						fillColor: "#ffffff",
+						symbol: "circle" // or callback
+					},
+					lines: {
+						// we don't put in show: false so we can see
+						// whether lines were actively disabled
+						lineWidth: 2, // in pixels
+						fill: false,
+						fillColor: null,
+						steps: false
+						// Omit 'zero', so we can later default its value to
+						// match that of the 'fill' option.
+					},
+					bars: {
+						show: false,
+						lineWidth: 2, // in pixels
+						barWidth: 1, // in units of the x axis
+						fill: true,
+						fillColor: null,
+						align: "left", // "left", "right", or "center"
+						horizontal: false,
+						zero: true
+					},
+					shadowSize: 3,
+					highlightColor: null
+				},
+				grid: {
+					show: true,
+					aboveData: false,
+					color: "#545454", // primary color used for outline and labels
+					backgroundColor: null, // null for transparent, else color
+					borderColor: null, // set if different from the grid color
+					tickColor: null, // color for the ticks, e.g. "rgba(0,0,0,0.15)"
+					margin: 0, // distance from the canvas edge to the grid
+					labelMargin: 5, // in pixels
+					axisMargin: 8, // in pixels
+					borderWidth: 2, // in pixels
+					minBorderMargin: null, // in pixels, null means taken from points radius
+					markings: null, // array of ranges or fn: axes -> array of ranges
+					markingsColor: "#f4f4f4",
+					markingsLineWidth: 2,
+					// interactive stuff
+					clickable: false,
+					hoverable: false,
+					autoHighlight: true, // highlight in case mouse is near
+					mouseActiveRadius: 10 // how far the mouse can be away to activate an item
+				},
+				interaction: {
+					redrawOverlayInterval: 1000/60 // time between updates, -1 means in same flow
+				},
+				hooks: {}
+			},
+		surface = null,     // the canvas for the plot itself
+		overlay = null,     // canvas for interactive stuff on top of plot
+		eventHolder = null, // jQuery object that events should be bound to
+		ctx = null, octx = null,
+		xaxes = [], yaxes = [],
+		plotOffset = { left: 0, right: 0, top: 0, bottom: 0},
+		plotWidth = 0, plotHeight = 0,
+		hooks = {
+			processOptions: [],
+			processRawData: [],
+			processDatapoints: [],
+			processOffset: [],
+			drawBackground: [],
+			drawSeries: [],
+			draw: [],
+			bindEvents: [],
+			drawOverlay: [],
+			shutdown: []
+		},
+		plot = this;
+
+		// public functions
+		plot.setData = setData;
+		plot.setupGrid = setupGrid;
+		plot.draw = draw;
+		plot.getPlaceholder = function() { return placeholder; };
+		plot.getCanvas = function() { return surface.element; };
+		plot.getPlotOffset = function() { return plotOffset; };
+		plot.width = function () { return plotWidth; };
+		plot.height = function () { return plotHeight; };
+		plot.offset = function () {
+			var o = eventHolder.offset();
+			o.left += plotOffset.left;
+			o.top += plotOffset.top;
+			return o;
+		};
+		plot.getData = function () { return series; };
+		plot.getAxes = function () {
+			var res = {}, i;
+			$.each(xaxes.concat(yaxes), function (_, axis) {
+				if (axis)
+					res[axis.direction + (axis.n != 1 ? axis.n : "") + "axis"] = axis;
+			});
+			return res;
+		};
+		plot.getXAxes = function () { return xaxes; };
+		plot.getYAxes = function () { return yaxes; };
+		plot.c2p = canvasToAxisCoords;
+		plot.p2c = axisToCanvasCoords;
+		plot.getOptions = function () { return options; };
+		plot.highlight = highlight;
+		plot.unhighlight = unhighlight;
+		plot.triggerRedrawOverlay = triggerRedrawOverlay;
+		plot.pointOffset = function(point) {
+			return {
+				left: parseInt(xaxes[axisNumber(point, "x") - 1].p2c(+point.x) + plotOffset.left, 10),
+				top: parseInt(yaxes[axisNumber(point, "y") - 1].p2c(+point.y) + plotOffset.top, 10)
+			};
+		};
+		plot.shutdown = shutdown;
+		plot.destroy = function () {
+			shutdown();
+			placeholder.removeData("plot").empty();
+
+			series = [];
+			options = null;
+			surface = null;
+			overlay = null;
+			eventHolder = null;
+			ctx = null;
+			octx = null;
+			xaxes = [];
+			yaxes = [];
+			hooks = null;
+			highlights = [];
+			plot = null;
+		};
+		plot.resize = function () {
+			var width = placeholder.width(),
+				height = placeholder.height();
+			surface.resize(width, height);
+			overlay.resize(width, height);
+		};
+
+		// public attributes
+		plot.hooks = hooks;
+
+		// initialize
+		initPlugins(plot);
+		parseOptions(options_);
+		setupCanvases();
+		setData(data_);
+		setupGrid();
+		draw();
+		bindEvents();
+
+
+		function executeHooks(hook, args) {
+			args = [plot].concat(args);
+			for (var i = 0; i < hook.length; ++i)
+				hook[i].apply(this, args);
+		}
+
+		function initPlugins() {
+
+			// References to key classes, allowing plugins to modify them
+
+			var classes = {
+				Canvas: Canvas
+			};
+
+			for (var i = 0; i < plugins.length; ++i) {
+				var p = plugins[i];
+				p.init(plot, classes);
+				if (p.options)
+					$.extend(true, options, p.options);
+			}
+		}
+
+		function parseOptions(opts) {
+
+			$.extend(true, options, opts);
+
+			// $.extend merges arrays, rather than replacing them.  When less
+			// colors are provided than the size of the default palette, we
+			// end up with those colors plus the remaining defaults, which is
+			// not expected behavior; avoid it by replacing them here.
+
+			if (opts && opts.colors) {
+				options.colors = opts.colors;
+			}
+
+			if (options.xaxis.color == null)
+				options.xaxis.color = $.color.parse(options.grid.color).scale('a', 0.22).toString();
+			if (options.yaxis.color == null)
+				options.yaxis.color = $.color.parse(options.grid.color).scale('a', 0.22).toString();
+
+			if (options.xaxis.tickColor == null) // grid.tickColor for back-compatibility
+				options.xaxis.tickColor = options.grid.tickColor || options.xaxis.color;
+			if (options.yaxis.tickColor == null) // grid.tickColor for back-compatibility
+				options.yaxis.tickColor = options.grid.tickColor || options.yaxis.color;
+
+			if (options.grid.borderColor == null)
+				options.grid.borderColor = options.grid.color;
+			if (options.grid.tickColor == null)
+				options.grid.tickColor = $.color.parse(options.grid.color).scale('a', 0.22).toString();
+
+			// Fill in defaults for axis options, including any unspecified
+			// font-spec fields, if a font-spec was provided.
+
+			// If no x/y axis options were provided, create one of each anyway,
+			// since the rest of the code assumes that they exist.
+
+			var i, axisOptions, axisCount,
+				fontSize = placeholder.css("font-size"),
+				fontSizeDefault = fontSize ? +fontSize.replace("px", "") : 13,
+				fontDefaults = {
+					style: placeholder.css("font-style"),
+					size: Math.round(0.8 * fontSizeDefault),
+					variant: placeholder.css("font-variant"),
+					weight: placeholder.css("font-weight"),
+					family: placeholder.css("font-family")
+				};
+
+			axisCount = options.xaxes.length || 1;
+			for (i = 0; i < axisCount; ++i) {
+
+				axisOptions = options.xaxes[i];
+				if (axisOptions && !axisOptions.tickColor) {
+					axisOptions.tickColor = axisOptions.color;
+				}
+
+				axisOptions = $.extend(true, {}, options.xaxis, axisOptions);
+				options.xaxes[i] = axisOptions;
+
+				if (axisOptions.font) {
+					axisOptions.font = $.extend({}, fontDefaults, axisOptions.font);
+					if (!axisOptions.font.color) {
+						axisOptions.font.color = axisOptions.color;
+					}
+					if (!axisOptions.font.lineHeight) {
+						axisOptions.font.lineHeight = Math.round(axisOptions.font.size * 1.15);
+					}
+				}
+			}
+
+			axisCount = options.yaxes.length || 1;
+			for (i = 0; i < axisCount; ++i) {
+
+				axisOptions = options.yaxes[i];
+				if (axisOptions && !axisOptions.tickColor) {
+					axisOptions.tickColor = axisOptions.color;
+				}
+
+				axisOptions = $.extend(true, {}, options.yaxis, axisOptions);
+				options.yaxes[i] = axisOptions;
+
+				if (axisOptions.font) {
+					axisOptions.font = $.extend({}, fontDefaults, axisOptions.font);
+					if (!axisOptions.font.color) {
+						axisOptions.font.color = axisOptions.color;
+					}
+					if (!axisOptions.font.lineHeight) {
+						axisOptions.font.lineHeight = Math.round(axisOptions.font.size * 1.15);
+					}
+				}
+			}
+
+			// backwards compatibility, to be removed in future
+			if (options.xaxis.noTicks && options.xaxis.ticks == null)
+				options.xaxis.ticks = options.xaxis.noTicks;
+			if (options.yaxis.noTicks && options.yaxis.ticks == null)
+				options.yaxis.ticks = options.yaxis.noTicks;
+			if (options.x2axis) {
+				options.xaxes[1] = $.extend(true, {}, options.xaxis, options.x2axis);
+				options.xaxes[1].position = "top";
+				// Override the inherit to allow the axis to auto-scale
+				if (options.x2axis.min == null) {
+					options.xaxes[1].min = null;
+				}
+				if (options.x2axis.max == null) {
+					options.xaxes[1].max = null;
+				}
+			}
+			if (options.y2axis) {
+				options.yaxes[1] = $.extend(true, {}, options.yaxis, options.y2axis);
+				options.yaxes[1].position = "right";
+				// Override the inherit to allow the axis to auto-scale
+				if (options.y2axis.min == null) {
+					options.yaxes[1].min = null;
+				}
+				if (options.y2axis.max == null) {
+					options.yaxes[1].max = null;
+				}
+			}
+			if (options.grid.coloredAreas)
+				options.grid.markings = options.grid.coloredAreas;
+			if (options.grid.coloredAreasColor)
+				options.grid.markingsColor = options.grid.coloredAreasColor;
+			if (options.lines)
+				$.extend(true, options.series.lines, options.lines);
+			if (options.points)
+				$.extend(true, options.series.points, options.points);
+			if (options.bars)
+				$.extend(true, options.series.bars, options.bars);
+			if (options.shadowSize != null)
+				options.series.shadowSize = options.shadowSize;
+			if (options.highlightColor != null)
+				options.series.highlightColor = options.highlightColor;
+
+			// save options on axes for future reference
+			for (i = 0; i < options.xaxes.length; ++i)
+				getOrCreateAxis(xaxes, i + 1).options = options.xaxes[i];
+			for (i = 0; i < options.yaxes.length; ++i)
+				getOrCreateAxis(yaxes, i + 1).options = options.yaxes[i];
+
+			// add hooks from options
+			for (var n in hooks)
+				if (options.hooks[n] && options.hooks[n].length)
+					hooks[n] = hooks[n].concat(options.hooks[n]);
+
+			executeHooks(hooks.processOptions, [options]);
+		}
+
+		function setData(d) {
+			series = parseData(d);
+			fillInSeriesOptions();
+			processData();
+		}
+
+		function parseData(d) {
+			var res = [];
+			for (var i = 0; i < d.length; ++i) {
+				var s = $.extend(true, {}, options.series);
+
+				if (d[i].data != null) {
+					s.data = d[i].data; // move the data instead of deep-copy
+					delete d[i].data;
+
+					$.extend(true, s, d[i]);
+
+					d[i].data = s.data;
+				}
+				else
+					s.data = d[i];
+				res.push(s);
+			}
+
+			return res;
+		}
+
+		function axisNumber(obj, coord) {
+			var a = obj[coord + "axis"];
+			if (typeof a == "object") // if we got a real axis, extract number
+				a = a.n;
+			if (typeof a != "number")
+				a = 1; // default to first axis
+			return a;
+		}
+
+		function allAxes() {
+			// return flat array without annoying null entries
+			return $.grep(xaxes.concat(yaxes), function (a) { return a; });
+		}
+
+		function canvasToAxisCoords(pos) {
+			// return an object with x/y corresponding to all used axes
+			var res = {}, i, axis;
+			for (i = 0; i < xaxes.length; ++i) {
+				axis = xaxes[i];
+				if (axis && axis.used)
+					res["x" + axis.n] = axis.c2p(pos.left);
+			}
+
+			for (i = 0; i < yaxes.length; ++i) {
+				axis = yaxes[i];
+				if (axis && axis.used)
+					res["y" + axis.n] = axis.c2p(pos.top);
+			}
+
+			if (res.x1 !== undefined)
+				res.x = res.x1;
+			if (res.y1 !== undefined)
+				res.y = res.y1;
+
+			return res;
+		}
+
+		function axisToCanvasCoords(pos) {
+			// get canvas coords from the first pair of x/y found in pos
+			var res = {}, i, axis, key;
+
+			for (i = 0; i < xaxes.length; ++i) {
+				axis = xaxes[i];
+				if (axis && axis.used) {
+					key = "x" + axis.n;
+					if (pos[key] == null && axis.n == 1)
+						key = "x";
+
+					if (pos[key] != null) {
+						res.left = axis.p2c(pos[key]);
+						break;
+					}
+				}
+			}
+
+			for (i = 0; i < yaxes.length; ++i) {
+				axis = yaxes[i];
+				if (axis && axis.used) {
+					key = "y" + axis.n;
+					if (pos[key] == null && axis.n == 1)
+						key = "y";
+
+					if (pos[key] != null) {
+						res.top = axis.p2c(pos[key]);
+						break;
+					}
+				}
+			}
+
+			return res;
+		}
+
+		function getOrCreateAxis(axes, number) {
+			if (!axes[number - 1])
+				axes[number - 1] = {
+					n: number, // save the number for future reference
+					direction: axes == xaxes ? "x" : "y",
+					options: $.extend(true, {}, axes == xaxes ? options.xaxis : options.yaxis)
+				};
+
+			return axes[number - 1];
+		}
+
+		function fillInSeriesOptions() {
+
+			var neededColors = series.length, maxIndex = -1, i;
+
+			// Subtract the number of series that already have fixed colors or
+			// color indexes from the number that we still need to generate.
+
+			for (i = 0; i < series.length; ++i) {
+				var sc = series[i].color;
+				if (sc != null) {
+					neededColors--;
+					if (typeof sc == "number" && sc > maxIndex) {
+						maxIndex = sc;
+					}
+				}
+			}
+
+			// If any of the series have fixed color indexes, then we need to
+			// generate at least as many colors as the highest index.
+
+			if (neededColors <= maxIndex) {
+				neededColors = maxIndex + 1;
+			}
+
+			// Generate all the colors, using first the option colors and then
+			// variations on those colors once they're exhausted.
+
+			var c, colors = [], colorPool = options.colors,
+				colorPoolSize = colorPool.length, variation = 0;
+
+			for (i = 0; i < neededColors; i++) {
+
+				c = $.color.parse(colorPool[i % colorPoolSize] || "#666");
+
+				// Each time we exhaust the colors in the pool we adjust
+				// a scaling factor used to produce more variations on
+				// those colors. The factor alternates negative/positive
+				// to produce lighter/darker colors.
+
+				// Reset the variation after every few cycles, or else
+				// it will end up producing only white or black colors.
+
+				if (i % colorPoolSize == 0 && i) {
+					if (variation >= 0) {
+						if (variation < 0.5) {
+							variation = -variation - 0.2;
+						} else variation = 0;
+					} else variation = -variation;
+				}
+
+				colors[i] = c.scale('rgb', 1 + variation);
+			}
+
+			// Finalize the series options, filling in their colors
+
+			var colori = 0, s;
+			for (i = 0; i < series.length; ++i) {
+				s = series[i];
+
+				// assign colors
+				if (s.color == null) {
+					s.color = colors[colori].toString();
+					++colori;
+				}
+				else if (typeof s.color == "number")
+					s.color = colors[s.color].toString();
+
+				// turn on lines automatically in case nothing is set
+				if (s.lines.show == null) {
+					var v, show = true;
+					for (v in s)
+						if (s[v] && s[v].show) {
+							show = false;
+							break;
+						}
+					if (show)
+						s.lines.show = true;
+				}
+
+				// If nothing was provided for lines.zero, default it to match
+				// lines.fill, since areas by default should extend to zero.
+
+				if (s.lines.zero == null) {
+					s.lines.zero = !!s.lines.fill;
+				}
+
+				// setup axes
+				s.xaxis = getOrCreateAxis(xaxes, axisNumber(s, "x"));
+				s.yaxis = getOrCreateAxis(yaxes, axisNumber(s, "y"));
+			}
+		}
+
+		function processData() {
+			var topSentry = Number.POSITIVE_INFINITY,
+				bottomSentry = Number.NEGATIVE_INFINITY,
+				fakeInfinity = Number.MAX_VALUE,
+				i, j, k, m, length,
+				s, points, ps, x, y, axis, val, f, p,
+				data, format;
+
+			function updateAxis(axis, min, max) {
+				if (min < axis.datamin && min != -fakeInfinity)
+					axis.datamin = min;
+				if (max > axis.datamax && max != fakeInfinity)
+					axis.datamax = max;
+			}
+
+			$.each(allAxes(), function (_, axis) {
+				// init axis
+				axis.datamin = topSentry;
+				axis.datamax = bottomSentry;
+				axis.used = false;
+			});
+
+			for (i = 0; i < series.length; ++i) {
+				s = series[i];
+				s.datapoints = { points: [] };
+
+				executeHooks(hooks.processRawData, [ s, s.data, s.datapoints ]);
+			}
+
+			// first pass: clean and copy data
+			for (i = 0; i < series.length; ++i) {
+				s = series[i];
+
+				data = s.data;
+				format = s.datapoints.format;
+
+				if (!format) {
+					format = [];
+					// find out how to copy
+					format.push({ x: true, number: true, required: true });
+					format.push({ y: true, number: true, required: true });
+
+					if (s.bars.show || (s.lines.show && s.lines.fill)) {
+						var autoscale = !!((s.bars.show && s.bars.zero) || (s.lines.show && s.lines.zero));
+						format.push({ y: true, number: true, required: false, defaultValue: 0, autoscale: autoscale });
+						if (s.bars.horizontal) {
+							delete format[format.length - 1].y;
+							format[format.length - 1].x = true;
+						}
+					}
+
+					s.datapoints.format = format;
+				}
+
+				if (s.datapoints.pointsize != null)
+					continue; // already filled in
+
+				s.datapoints.pointsize = format.length;
+
+				ps = s.datapoints.pointsize;
+				points = s.datapoints.points;
+
+				var insertSteps = s.lines.show && s.lines.steps;
+				s.xaxis.used = s.yaxis.used = true;
+
+				for (j = k = 0; j < data.length; ++j, k += ps) {
+					p = data[j];
+
+					var nullify = p == null;
+					if (!nullify) {
+						for (m = 0; m < ps; ++m) {
+							val = p[m];
+							f = format[m];
+
+							if (f) {
+								if (f.number && val != null) {
+									val = +val; // convert to number
+									if (isNaN(val))
+										val = null;
+									else if (val == Infinity)
+										val = fakeInfinity;
+									else if (val == -Infinity)
+										val = -fakeInfinity;
+								}
+
+								if (val == null) {
+									if (f.required)
+										nullify = true;
+
+									if (f.defaultValue != null)
+										val = f.defaultValue;
+								}
+							}
+
+							points[k + m] = val;
+						}
+					}
+
+					if (nullify) {
+						for (m = 0; m < ps; ++m) {
+							val = points[k + m];
+							if (val != null) {
+								f = format[m];
+								// extract min/max info
+								if (f.autoscale !== false) {
+									if (f.x) {
+										updateAxis(s.xaxis, val, val);
+									}
+									if (f.y) {
+										updateAxis(s.yaxis, val, val);
+									}
+								}
+							}
+							points[k + m] = null;
+						}
+					}
+					else {
+						// a little bit of line specific stuff that
+						// perhaps shouldn't be here, but lacking
+						// better means...
+						if (insertSteps && k > 0
+							&& points[k - ps] != null
+							&& points[k - ps] != points[k]
+							&& points[k - ps + 1] != points[k + 1]) {
+							// copy the point to make room for a middle point
+							for (m = 0; m < ps; ++m)
+								points[k + ps + m] = points[k + m];
+
+							// middle point has same y
+							points[k + 1] = points[k - ps + 1];
+
+							// we've added a point, better reflect that
+							k += ps;
+						}
+					}
+				}
+			}
+
+			// give the hooks a chance to run
+			for (i = 0; i < series.length; ++i) {
+				s = series[i];
+
+				executeHooks(hooks.processDatapoints, [ s, s.datapoints]);
+			}
+
+			// second pass: find datamax/datamin for auto-scaling
+			for (i = 0; i < series.length; ++i) {
+				s = series[i];
+				points = s.datapoints.points;
+				ps = s.datapoints.pointsize;
+				format = s.datapoints.format;
+
+				var xmin = topSentry, ymin = topSentry,
+					xmax = bottomSentry, ymax = bottomSentry;
+
+				for (j = 0; j < points.length; j += ps) {
+					if (points[j] == null)
+						continue;
+
+					for (m = 0; m < ps; ++m) {
+						val = points[j + m];
+						f = format[m];
+						if (!f || f.autoscale === false || val == fakeInfinity || val == -fakeInfinity)
+							continue;
+
+						if (f.x) {
+							if (val < xmin)
+								xmin = val;
+							if (val > xmax)
+								xmax = val;
+						}
+						if (f.y) {
+							if (val < ymin)
+								ymin = val;
+							if (val > ymax)
+								ymax = val;
+						}
+					}
+				}
+
+				if (s.bars.show) {
+					// make sure we got room for the bar on the dancing floor
+					var delta;
+
+					switch (s.bars.align) {
+						case "left":
+							delta = 0;
+							break;
+						case "right":
+							delta = -s.bars.barWidth;
+							break;
+						default:
+							delta = -s.bars.barWidth / 2;
+					}
+
+					if (s.bars.horizontal) {
+						ymin += delta;
+						ymax += delta + s.bars.barWidth;
+					}
+					else {
+						xmin += delta;
+						xmax += delta + s.bars.barWidth;
+					}
+				}
+
+				updateAxis(s.xaxis, xmin, xmax);
+				updateAxis(s.yaxis, ymin, ymax);
+			}
+
+			$.each(allAxes(), function (_, axis) {
+				if (axis.datamin == topSentry)
+					axis.datamin = null;
+				if (axis.datamax == bottomSentry)
+					axis.datamax = null;
+			});
+		}
+
+		function setupCanvases() {
+
+			// Make sure the placeholder is clear of everything except canvases
+			// from a previous plot in this container that we'll try to re-use.
+
+			placeholder.css("padding", 0) // padding messes up the positioning
+				.children().filter(function(){
+					return !$(this).hasClass("flot-overlay") && !$(this).hasClass('flot-base');
+				}).remove();
+
+			if (placeholder.css("position") == 'static')
+				placeholder.css("position", "relative"); // for positioning labels and overlay
+
+			surface = new Canvas("flot-base", placeholder);
+			overlay = new Canvas("flot-overlay", placeholder); // overlay canvas for interactive features
+
+			ctx = surface.context;
+			octx = overlay.context;
+
+			// define which element we're listening for events on
+			eventHolder = $(overlay.element).unbind();
+
+			// If we're re-using a plot object, shut down the old one
+
+			var existing = placeholder.data("plot");
+
+			if (existing) {
+				existing.shutdown();
+				overlay.clear();
+			}
+
+			// save in case we get replotted
+			placeholder.data("plot", plot);
+		}
+
+		function bindEvents() {
+			// bind events
+			if (options.grid.hoverable) {
+				eventHolder.mousemove(onMouseMove);
+
+				// Use bind, rather than .mouseleave, because we officially
+				// still support jQuery 1.2.6, which doesn't define a shortcut
+				// for mouseenter or mouseleave.  This was a bug/oversight that
+				// was fixed somewhere around 1.3.x.  We can return to using
+				// .mouseleave when we drop support for 1.2.6.
+
+				eventHolder.bind("mouseleave", onMouseLeave);
+			}
+
+			if (options.grid.clickable)
+				eventHolder.click(onClick);
+
+			executeHooks(hooks.bindEvents, [eventHolder]);
+		}
+
+		function shutdown() {
+			if (redrawTimeout)
+				clearTimeout(redrawTimeout);
+
+			eventHolder.unbind("mousemove", onMouseMove);
+			eventHolder.unbind("mouseleave", onMouseLeave);
+			eventHolder.unbind("click", onClick);
+
+			executeHooks(hooks.shutdown, [eventHolder]);
+		}
+
+		function setTransformationHelpers(axis) {
+			// set helper functions on the axis, assumes plot area
+			// has been computed already
+
+			function identity(x) { return x; }
+
+			var s, m, t = axis.options.transform || identity,
+				it = axis.options.inverseTransform;
+
+			// precompute how much the axis is scaling a point
+			// in canvas space
+			if (axis.direction == "x") {
+				s = axis.scale = plotWidth / Math.abs(t(axis.max) - t(axis.min));
+				m = Math.min(t(axis.max), t(axis.min));
+			}
+			else {
+				s = axis.scale = plotHeight / Math.abs(t(axis.max) - t(axis.min));
+				s = -s;
+				m = Math.max(t(axis.max), t(axis.min));
+			}
+
+			// data point to canvas coordinate
+			if (t == identity) // slight optimization
+				axis.p2c = function (p) { return (p - m) * s; };
+			else
+				axis.p2c = function (p) { return (t(p) - m) * s; };
+			// canvas coordinate to data point
+			if (!it)
+				axis.c2p = function (c) { return m + c / s; };
+			else
+				axis.c2p = function (c) { return it(m + c / s); };
+		}
+
+		function measureTickLabels(axis) {
+
+			var opts = axis.options,
+				ticks = axis.ticks || [],
+				labelWidth = opts.labelWidth || 0,
+				labelHeight = opts.labelHeight || 0,
+				maxWidth = labelWidth || (axis.direction == "x" ? Math.floor(surface.width / (ticks.length || 1)) : null),
+				legacyStyles = axis.direction + "Axis " + axis.direction + axis.n + "Axis",
+				layer = "flot-" + axis.direction + "-axis flot-" + axis.direction + axis.n + "-axis " + legacyStyles,
+				font = opts.font || "flot-tick-label tickLabel";
+
+			for (var i = 0; i < ticks.length; ++i) {
+
+				var t = ticks[i];
+
+				if (!t.label)
+					continue;
+
+				var info = surface.getTextInfo(layer, t.label, font, null, maxWidth);
+
+				labelWidth = Math.max(labelWidth, info.width);
+				labelHeight = Math.max(labelHeight, info.height);
+			}
+
+			axis.labelWidth = opts.labelWidth || labelWidth;
+			axis.labelHeight = opts.labelHeight || labelHeight;
+		}
+
+		function allocateAxisBoxFirstPhase(axis) {
+			// find the bounding box of the axis by looking at label
+			// widths/heights and ticks, make room by diminishing the
+			// plotOffset; this first phase only looks at one
+			// dimension per axis, the other dimension depends on the
+			// other axes so will have to wait
+
+			var lw = axis.labelWidth,
+				lh = axis.labelHeight,
+				pos = axis.options.position,
+				isXAxis = axis.direction === "x",
+				tickLength = axis.options.tickLength,
+				axisMargin = options.grid.axisMargin,
+				padding = options.grid.labelMargin,
+				innermost = true,
+				outermost = true,
+				first = true,
+				found = false;
+
+			// Determine the axis's position in its direction and on its side
+
+			$.each(isXAxis ? xaxes : yaxes, function(i, a) {
+				if (a && (a.show || a.reserveSpace)) {
+					if (a === axis) {
+						found = true;
+					} else if (a.options.position === pos) {
+						if (found) {
+							outermost = false;
+						} else {
+							innermost = false;
+						}
+					}
+					if (!found) {
+						first = false;
+					}
+				}
+			});
+
+			// The outermost axis on each side has no margin
+
+			if (outermost) {
+				axisMargin = 0;
+			}
+
+			// The ticks for the first axis in each direction stretch across
+
+			if (tickLength == null) {
+				tickLength = first ? "full" : 5;
+			}
+
+			if (!isNaN(+tickLength))
+				padding += +tickLength;
+
+			if (isXAxis) {
+				lh += padding;
+
+				if (first && axis.options.labelPosition == 'inside') {
+					// x-axis with labels inside
+					lh += padding; // double padding for upper/lower space
+					if (pos == "bottom") {
+						axis.box = { top: surface.height - (lh + axisMargin), height: lh };
+					}
+					else {
+						axis.box = { top: plotOffset.top + axisMargin, height: lh };
+					}
+				}
+				else {
+					if (pos == "bottom") {
+						plotOffset.bottom += lh + axisMargin;
+						axis.box = { top: surface.height - plotOffset.bottom, height: lh };
+					}
+					else {
+						axis.box = { top: plotOffset.top + axisMargin, height: lh };
+						plotOffset.top += lh + axisMargin;
+					}
+				}
+			}
+			else {
+				lw += padding;
+				if (first && axis.options.labelPosition == 'inside') {
+					// y-axis with labels inside
+					lw += padding; // double padding for upper/lower space
+					if (pos == "left") {
+						axis.box = { left: plotOffset.left + axisMargin, width: lw };
+					}
+					else {
+						axis.box = { left: surface.width - (lw + axisMargin), width: lw };
+					}
+				}
+				else {
+					if (pos == "left") {
+						axis.box = { left: plotOffset.left + axisMargin, width: lw };
+						plotOffset.left += lw + axisMargin;
+					}
+					else {
+						plotOffset.right += lw + axisMargin;
+						axis.box = { left: surface.width - plotOffset.right, width: lw };
+					}
+				}
+			}
+
+			 // save for future reference
+			axis.position = pos;
+			axis.tickLength = tickLength;
+			axis.box.padding = padding;
+			axis.innermost = innermost;
+		}
+
+		function allocateAxisBoxSecondPhase(axis) {
+			// now that all axis boxes have been placed in one
+			// dimension, we can set the remaining dimension coordinates
+			if (axis.direction == "x") {
+				axis.box.left = plotOffset.left - axis.labelWidth / 2;
+				axis.box.width = surface.width - plotOffset.left - plotOffset.right + axis.labelWidth;
+			}
+			else {
+				axis.box.top = plotOffset.top - axis.labelHeight / 2;
+				axis.box.height = surface.height - plotOffset.bottom - plotOffset.top + axis.labelHeight;
+			}
+		}
+
+		function adjustLayoutForThingsStickingOut() {
+			// possibly adjust plot offset to ensure everything stays
+			// inside the canvas and isn't clipped off
+
+			var minMargin = options.grid.minBorderMargin,
+				axis, i;
+
+			// check stuff from the plot (FIXME: this should just read
+			// a value from the series, otherwise it's impossible to
+			// customize)
+			if (minMargin == null) {
+				minMargin = 0;
+				for (i = 0; i < series.length; ++i)
+					minMargin = Math.max(minMargin, 2 * (series[i].points.radius + series[i].points.lineWidth/2));
+			}
+
+			var margins = {
+				left: minMargin,
+				right: minMargin,
+				top: minMargin,
+				bottom: minMargin
+			};
+
+			// check axis labels, note we don't check the actual
+			// labels but instead use the overall width/height to not
+			// jump as much around with replots
+			$.each(allAxes(), function (_, axis) {
+				if (axis.reserveSpace && axis.ticks && axis.ticks.length) {
+					if (axis.direction === "x") {
+						margins.left = Math.max(margins.left, axis.labelWidth / 2);
+						margins.right = Math.max(margins.right, axis.labelWidth / 2);
+					} else {
+						margins.bottom = Math.max(margins.bottom, axis.labelHeight / 2);
+						margins.top = Math.max(margins.top, axis.labelHeight / 2);
+					}
+				}
+			});
+
+			plotOffset.left = Math.ceil(Math.max(margins.left, plotOffset.left));
+			plotOffset.right = Math.ceil(Math.max(margins.right, plotOffset.right));
+			plotOffset.top = Math.ceil(Math.max(margins.top, plotOffset.top));
+			plotOffset.bottom = Math.ceil(Math.max(margins.bottom, plotOffset.bottom));
+		}
+
+		function setupGrid() {
+			var i, axes = allAxes(), showGrid = options.grid.show;
+
+			// Initialize the plot's offset from the edge of the canvas
+
+			for (var a in plotOffset) {
+				var margin = options.grid.margin || 0;
+				plotOffset[a] = typeof margin == "number" ? margin : margin[a] || 0;
+			}
+
+			executeHooks(hooks.processOffset, [plotOffset]);
+
+			// If the grid is visible, add its border width to the offset
+
+			for (var a in plotOffset) {
+				if(typeof(options.grid.borderWidth) == "object") {
+					plotOffset[a] += showGrid ? options.grid.borderWidth[a] : 0;
+				}
+				else {
+					plotOffset[a] += showGrid ? options.grid.borderWidth : 0;
+				}
+			}
+
+			$.each(axes, function (_, axis) {
+				var axisOpts = axis.options;
+				axis.show = axisOpts.show == null ? axis.used : axisOpts.show;
+				axis.reserveSpace = axisOpts.reserveSpace == null ? axis.show : axisOpts.reserveSpace;
+				setRange(axis);
+			});
+
+			if (showGrid) {
+
+				var allocatedAxes = $.grep(axes, function (axis) {
+					return axis.show || axis.reserveSpace;
+				});
+
+				$.each(allocatedAxes, function (_, axis) {
+					// make the ticks
+					setupTickGeneration(axis);
+					setTicks(axis);
+					snapRangeToTicks(axis, axis.ticks);
+					// find labelWidth/Height for axis
+					measureTickLabels(axis);
+				});
+
+				// with all dimensions calculated, we can compute the
+				// axis bounding boxes, start from the outside
+				// (reverse order)
+				for (i = allocatedAxes.length - 1; i >= 0; --i)
+					allocateAxisBoxFirstPhase(allocatedAxes[i]);
+
+				// make sure we've got enough space for things that
+				// might stick out
+				adjustLayoutForThingsStickingOut();
+
+				$.each(allocatedAxes, function (_, axis) {
+					allocateAxisBoxSecondPhase(axis);
+				});
+			}
+
+			plotWidth = surface.width - plotOffset.left - plotOffset.right;
+			plotHeight = surface.height - plotOffset.bottom - plotOffset.top;
+
+			// now we got the proper plot dimensions, we can compute the scaling
+			$.each(axes, function (_, axis) {
+				setTransformationHelpers(axis);
+			});
+
+			insertLegend();
+		}
+
+		function setRange(axis) {
+			var opts = axis.options,
+				min = +(opts.min != null ? opts.min : axis.datamin),
+				max = +(opts.max != null ? opts.max : axis.datamax),
+				delta = max - min;
+
+			if (delta == 0.0) {
+				// degenerate case
+				var widen = max == 0 ? 1 : 0.01;
+
+				if (opts.min == null)
+					min -= widen;
+				// always widen max if we couldn't widen min to ensure we
+				// don't fall into min == max which doesn't work
+				if (opts.max == null || opts.min != null)
+					max += widen;
+			}
+			else {
+				// consider autoscaling
+				var margin = opts.autoscaleMargin;
+				if (margin != null) {
+					if (opts.min == null) {
+						min -= delta * margin;
+						// make sure we don't go below zero if all values
+						// are positive
+						if (min < 0 && axis.datamin != null && axis.datamin >= 0)
+							min = 0;
+					}
+					if (opts.max == null) {
+						max += delta * margin;
+						if (max > 0 && axis.datamax != null && axis.datamax <= 0)
+							max = 0;
+					}
+				}
+			}
+			axis.min = min;
+			axis.max = max;
+		}
+
+		function setupTickGeneration(axis) {
+			var opts = axis.options;
+
+			// estimate number of ticks
+			var noTicks;
+			if (typeof opts.ticks == "number" && opts.ticks > 0)
+				noTicks = opts.ticks;
+			else
+				// heuristic based on the model a*sqrt(x) fitted to
+				// some data points that seemed reasonable
+				noTicks = 0.3 * Math.sqrt(axis.direction == "x" ? surface.width : surface.height);
+
+			var delta = (axis.max - axis.min) / noTicks,
+				dec = -Math.floor(Math.log(delta) / Math.LN10),
+				maxDec = opts.tickDecimals;
+
+			if (maxDec != null && dec > maxDec) {
+				dec = maxDec;
+			}
+
+			var magn = Math.pow(10, -dec),
+				norm = delta / magn, // norm is between 1.0 and 10.0
+				size;
+
+			if (norm < 1.5) {
+				size = 1;
+			} else if (norm < 3) {
+				size = 2;
+				// special case for 2.5, requires an extra decimal
+				if (norm > 2.25 && (maxDec == null || dec + 1 <= maxDec)) {
+					size = 2.5;
+					++dec;
+				}
+			} else if (norm < 7.5) {
+				size = 5;
+			} else {
+				size = 10;
+			}
+
+			size *= magn;
+
+			if (opts.minTickSize != null && size < opts.minTickSize) {
+				size = opts.minTickSize;
+			}
+
+			axis.delta = delta;
+			axis.tickDecimals = Math.max(0, maxDec != null ? maxDec : dec);
+			axis.tickSize = opts.tickSize || size;
+
+			// Time mode was moved to a plug-in in 0.8, and since so many people use it
+			// we'll add an especially friendly reminder to make sure they included it.
+
+			if (opts.mode == "time" && !axis.tickGenerator) {
+				throw new Error("Time mode requires the flot.time plugin.");
+			}
+
+			// Flot supports base-10 axes; any other mode else is handled by a plug-in,
+			// like flot.time.js.
+
+			if (!axis.tickGenerator) {
+
+				axis.tickGenerator = function (axis) {
+
+					var ticks = [],
+						start = floorInBase(axis.min, axis.tickSize),
+						i = 0,
+						v = Number.NaN,
+						prev;
+
+					do {
+						prev = v;
+						v = start + i * axis.tickSize;
+						ticks.push(v);
+						++i;
+					} while (v < axis.max && v != prev);
+					return ticks;
+				};
 
 				axis.tickFormatter = function (value, axis) {
 
@@ -1774,1395 +1793,1454 @@ Licensed under the MIT license.
 						}
 					}
 
-                    return formatted;
-                };
-            }
-
-            if ($.isFunction(opts.tickFormatter))
-                axis.tickFormatter = function (v, axis) { return "" + opts.tickFormatter(v, axis); };
-
-            if (opts.alignTicksWithAxis != null) {
-                var otherAxis = (axis.direction == "x" ? xaxes : yaxes)[opts.alignTicksWithAxis - 1];
-                if (otherAxis && otherAxis.used && otherAxis != axis) {
-                    // consider snapping min/max to outermost nice ticks
-                    var niceTicks = axis.tickGenerator(axis);
-                    if (niceTicks.length > 0) {
-                        if (opts.min == null)
-                            axis.min = Math.min(axis.min, niceTicks[0]);
-                        if (opts.max == null && niceTicks.length > 1)
-                            axis.max = Math.max(axis.max, niceTicks[niceTicks.length - 1]);
-                    }
-
-                    axis.tickGenerator = function (axis) {
-                        // copy ticks, scaled to this axis
-                        var ticks = [], v, i;
-                        for (i = 0; i < otherAxis.ticks.length; ++i) {
-                            v = (otherAxis.ticks[i].v - otherAxis.min) / (otherAxis.max - otherAxis.min);
-                            v = axis.min + v * (axis.max - axis.min);
-                            ticks.push(v);
-                        }
-                        return ticks;
-                    };
-
-                    // we might need an extra decimal since forced
-                    // ticks don't necessarily fit naturally
-                    if (!axis.mode && opts.tickDecimals == null) {
-                        var extraDec = Math.max(0, -Math.floor(Math.log(axis.delta) / Math.LN10) + 1),
-                            ts = axis.tickGenerator(axis);
-
-                        // only proceed if the tick interval rounded
-                        // with an extra decimal doesn't give us a
-                        // zero at end
-                        if (!(ts.length > 1 && /\..*0$/.test((ts[1] - ts[0]).toFixed(extraDec))))
-                            axis.tickDecimals = extraDec;
-                    }
-                }
-            }
-        }
-
-        function setTicks(axis) {
-            var oticks = axis.options.ticks, ticks = [];
-            if (oticks == null || (typeof oticks == "number" && oticks > 0))
-                ticks = axis.tickGenerator(axis);
-            else if (oticks) {
-                if ($.isFunction(oticks))
-                    // generate the ticks
-                    ticks = oticks(axis);
-                else
-                    ticks = oticks;
-            }
-
-            // clean up/labelify the supplied ticks, copy them over
-            var i, v;
-            axis.ticks = [];
-            for (i = 0; i < ticks.length; ++i) {
-                var label = null;
-                var t = ticks[i];
-                if (typeof t == "object") {
-                    v = +t[0];
-                    if (t.length > 1)
-                        label = t[1];
-                }
-                else
-                    v = +t;
-                if (label == null)
-                    label = axis.tickFormatter(v, axis);
-                if (!isNaN(v))
-                    axis.ticks.push({ v: v, label: label });
-            }
-        }
-
-        function snapRangeToTicks(axis, ticks) {
-            if (axis.options.autoscaleMargin && ticks.length > 0) {
-                // snap to ticks
-                if (axis.options.min == null)
-                    axis.min = Math.min(axis.min, ticks[0].v);
-                if (axis.options.max == null && ticks.length > 1)
-                    axis.max = Math.max(axis.max, ticks[ticks.length - 1].v);
-            }
-        }
-
-        function draw() {
-
-            surface.clear();
-
-            executeHooks(hooks.drawBackground, [ctx]);
-
-            var grid = options.grid;
-
-            // draw background, if any
-            if (grid.show && grid.backgroundColor)
-                drawBackground();
-
-            if (grid.show && !grid.aboveData) {
-                drawGrid();
-            }
-
-            for (var i = 0; i < series.length; ++i) {
-                executeHooks(hooks.drawSeries, [ctx, series[i]]);
-                drawSeries(series[i]);
-            }
-
-            executeHooks(hooks.draw, [ctx]);
-
-            if (grid.show && grid.aboveData) {
-                drawGrid();
-            }
-
-            surface.render();
-
-            // A draw implies that either the axes or data have changed, so we
-            // should probably update the overlay highlights as well.
-
-            triggerRedrawOverlay();
-        }
-
-        function extractRange(ranges, coord) {
-            var axis, from, to, key, axes = allAxes();
-
-            for (var i = 0; i < axes.length; ++i) {
-                axis = axes[i];
-                if (axis.direction == coord) {
-                    key = coord + axis.n + "axis";
-                    if (!ranges[key] && axis.n == 1)
-                        key = coord + "axis"; // support x1axis as xaxis
-                    if (ranges[key]) {
-                        from = ranges[key].from;
-                        to = ranges[key].to;
-                        break;
-                    }
-                }
-            }
-
-            // backwards-compat stuff - to be removed in future
-            if (!ranges[key]) {
-                axis = coord == "x" ? xaxes[0] : yaxes[0];
-                from = ranges[coord + "1"];
-                to = ranges[coord + "2"];
-            }
-
-            // auto-reverse as an added bonus
-            if (from != null && to != null && from > to) {
-                var tmp = from;
-                from = to;
-                to = tmp;
-            }
-
-            return { from: from, to: to, axis: axis };
-        }
-
-        function drawBackground() {
-            ctx.save();
-            ctx.translate(plotOffset.left, plotOffset.top);
-
-            ctx.fillStyle = getColorOrGradient(options.grid.backgroundColor, plotHeight, 0, "rgba(255, 255, 255, 0)");
-            ctx.fillRect(0, 0, plotWidth, plotHeight);
-            ctx.restore();
-        }
-
-        function drawGrid() {
-            var i, axes, bw, bc;
-
-            ctx.save();
-            ctx.translate(plotOffset.left, plotOffset.top);
-
-            // draw markings
-            var markings = options.grid.markings;
-            if (markings) {
-                if ($.isFunction(markings)) {
-                    axes = plot.getAxes();
-                    // xmin etc. is backwards compatibility, to be
-                    // removed in the future
-                    axes.xmin = axes.xaxis.min;
-                    axes.xmax = axes.xaxis.max;
-                    axes.ymin = axes.yaxis.min;
-                    axes.ymax = axes.yaxis.max;
-
-                    markings = markings(axes);
-                }
-
-                for (i = 0; i < markings.length; ++i) {
-                    var m = markings[i],
-                        xrange = extractRange(m, "x"),
-                        yrange = extractRange(m, "y");
-
-                    // fill in missing
-                    if (xrange.from == null)
-                        xrange.from = xrange.axis.min;
-                    if (xrange.to == null)
-                        xrange.to = xrange.axis.max;
-                    if (yrange.from == null)
-                        yrange.from = yrange.axis.min;
-                    if (yrange.to == null)
-                        yrange.to = yrange.axis.max;
-
-                    // clip
-                    if (xrange.to < xrange.axis.min || xrange.from > xrange.axis.max ||
-                        yrange.to < yrange.axis.min || yrange.from > yrange.axis.max)
-                        continue;
-
-                    xrange.from = Math.max(xrange.from, xrange.axis.min);
-                    xrange.to = Math.min(xrange.to, xrange.axis.max);
-                    yrange.from = Math.max(yrange.from, yrange.axis.min);
-                    yrange.to = Math.min(yrange.to, yrange.axis.max);
-
-                    var xequal = xrange.from === xrange.to,
-                        yequal = yrange.from === yrange.to;
-
-                    if (xequal && yequal) {
-                        continue;
-                    }
-
-                    // then draw
-                    xrange.from = Math.floor(xrange.axis.p2c(xrange.from));
-                    xrange.to = Math.floor(xrange.axis.p2c(xrange.to));
-                    yrange.from = Math.floor(yrange.axis.p2c(yrange.from));
-                    yrange.to = Math.floor(yrange.axis.p2c(yrange.to));
-
-                    if (xequal || yequal) {
-                        var lineWidth = m.lineWidth || options.grid.markingsLineWidth,
-                            subPixel = lineWidth % 2 ? 0.5 : 0;
-                        ctx.beginPath();
-                        ctx.strokeStyle = m.color || options.grid.markingsColor;
-                        ctx.lineWidth = lineWidth;
-                        if (xequal) {
-                            ctx.moveTo(xrange.to + subPixel, yrange.from);
-                            ctx.lineTo(xrange.to + subPixel, yrange.to);
-                        } else {
-                            ctx.moveTo(xrange.from, yrange.to + subPixel);
-                            ctx.lineTo(xrange.to, yrange.to + subPixel);                            
-                        }
-                        ctx.stroke();
-                    } else {
-                        ctx.fillStyle = m.color || options.grid.markingsColor;
-                        ctx.fillRect(xrange.from, yrange.to,
-                                     xrange.to - xrange.from,
-                                     yrange.from - yrange.to);
-                    }
-                }
-            }
-
-            // draw the ticks
-            axes = allAxes();
-            bw = options.grid.borderWidth;
-
-            for (var j = 0; j < axes.length; ++j) {
-                var axis = axes[j], box = axis.box,
-                    t = axis.tickLength, x, y, xoff, yoff;
-                if (!axis.show || axis.ticks.length == 0)
-                    continue;
-
-                ctx.lineWidth = 1;
-
-                // find the edges
-                if (axis.direction == "x") {
-                    x = 0;
-                    if (t == "full")
-                        y = (axis.position == "top" ? 0 : plotHeight);
-                    else
-                        y = box.top - plotOffset.top + (axis.position == "top" ? box.height : 0);
-                }
-                else {
-                    y = 0;
-                    if (t == "full")
-                        x = (axis.position == "left" ? 0 : plotWidth);
-                    else
-                        x = box.left - plotOffset.left + (axis.position == "left" ? box.width : 0);
-                }
-
-                // draw tick bar
-                if (!axis.innermost) {
-                    ctx.strokeStyle = axis.options.color;
-                    ctx.beginPath();
-                    xoff = yoff = 0;
-                    if (axis.direction == "x")
-                        xoff = plotWidth + 1;
-                    else
-                        yoff = plotHeight + 1;
-
-                    if (ctx.lineWidth == 1) {
-                        if (axis.direction == "x") {
-                            y = Math.floor(y) + 0.5;
-                        } else {
-                            x = Math.floor(x) + 0.5;
-                        }
-                    }
-
-                    ctx.moveTo(x, y);
-                    ctx.lineTo(x + xoff, y + yoff);
-                    ctx.stroke();
-                }
-
-                // draw ticks
-
-                ctx.strokeStyle = axis.options.tickColor;
-
-                ctx.beginPath();
-                for (i = 0; i < axis.ticks.length; ++i) {
-                    var v = axis.ticks[i].v;
-
-                    xoff = yoff = 0;
-
-                    if (isNaN(v) || v < axis.min || v > axis.max
-                        // skip those lying on the axes if we got a border
-                        || (t == "full"
-                            && ((typeof bw == "object" && bw[axis.position] > 0) || bw > 0)
-                            && (v == axis.min || v == axis.max)))
-                        continue;
-
-                    if (axis.direction == "x") {
-                        x = axis.p2c(v);
-                        yoff = t == "full" ? -plotHeight : t;
-
-                        if (axis.position == "top")
-                            yoff = -yoff;
-                    }
-                    else {
-                        y = axis.p2c(v);
-                        xoff = t == "full" ? -plotWidth : t;
-
-                        if (axis.position == "left")
-                            xoff = -xoff;
-                    }
-
-                    if (ctx.lineWidth == 1) {
-                        if (axis.direction == "x")
-                            x = Math.floor(x) + 0.5;
-                        else
-                            y = Math.floor(y) + 0.5;
-                    }
-
-                    ctx.moveTo(x, y);
-                    ctx.lineTo(x + xoff, y + yoff);
-                }
-
-                ctx.stroke();
-            }
-
-
-            // draw border
-            if (bw) {
-                // If either borderWidth or borderColor is an object, then draw the border
-                // line by line instead of as one rectangle
-                bc = options.grid.borderColor;
-                if(typeof bw == "object" || typeof bc == "object") {
-                    if (typeof bw !== "object") {
-                        bw = {top: bw, right: bw, bottom: bw, left: bw};
-                    }
-                    if (typeof bc !== "object") {
-                        bc = {top: bc, right: bc, bottom: bc, left: bc};
-                    }
-
-                    if (bw.top > 0) {
-                        ctx.strokeStyle = bc.top;
-                        ctx.lineWidth = bw.top;
-                        ctx.beginPath();
-                        ctx.moveTo(0 - bw.left, 0 - bw.top/2);
-                        ctx.lineTo(plotWidth, 0 - bw.top/2);
-                        ctx.stroke();
-                    }
-
-                    if (bw.right > 0) {
-                        ctx.strokeStyle = bc.right;
-                        ctx.lineWidth = bw.right;
-                        ctx.beginPath();
-                        ctx.moveTo(plotWidth + bw.right / 2, 0 - bw.top);
-                        ctx.lineTo(plotWidth + bw.right / 2, plotHeight);
-                        ctx.stroke();
-                    }
-
-                    if (bw.bottom > 0) {
-                        ctx.strokeStyle = bc.bottom;
-                        ctx.lineWidth = bw.bottom;
-                        ctx.beginPath();
-                        ctx.moveTo(plotWidth + bw.right, plotHeight + bw.bottom / 2);
-                        ctx.lineTo(0, plotHeight + bw.bottom / 2);
-                        ctx.stroke();
-                    }
-
-                    if (bw.left > 0) {
-                        ctx.strokeStyle = bc.left;
-                        ctx.lineWidth = bw.left;
-                        ctx.beginPath();
-                        ctx.moveTo(0 - bw.left/2, plotHeight + bw.bottom);
-                        ctx.lineTo(0- bw.left/2, 0);
-                        ctx.stroke();
-                    }
-                }
-                else {
-                    ctx.lineWidth = bw;
-                    ctx.strokeStyle = options.grid.borderColor;
-                    ctx.strokeRect(-bw/2, -bw/2, plotWidth + bw, plotHeight + bw);
-                }
-            }
-
-            ctx.restore();
-        }
-
-        function drawAxisLabels() {
-
-            $.each(allAxes(), function (_, axis) {
-                var box = axis.box,
-                    legacyStyles = axis.direction + "Axis " + axis.direction + axis.n + "Axis",
-                    layer = "flot-" + axis.direction + "-axis flot-" + axis.direction + axis.n + "-axis " + legacyStyles,
-                    font = axis.options.font || "flot-tick-label tickLabel",
-                    tick, x, y, halign, valign;
-
-                // Remove text before checking for axis.show and ticks.length;
-                // otherwise plugins, like flot-tickrotor, that draw their own
-                // tick labels will end up with both theirs and the defaults.
-
-                surface.removeText(layer);
-
-                if (!axis.show || axis.ticks.length == 0)
-                    return;
-
-                for (var i = 0; i < axis.ticks.length; ++i) {
-
-                    tick = axis.ticks[i];
-                    if (!tick.label || tick.v < axis.min || tick.v > axis.max)
-                        continue;
-
-                    if (axis.direction == "x") {
-                        halign = "center";
-                        x = plotOffset.left + axis.p2c(tick.v);
-                        if (axis.position == "bottom") {
-                            y = box.top + box.padding;
-                        } else {
-                            y = box.top + box.height - box.padding;
-                            valign = "bottom";
-                        }
-                    } else {
-                        valign = "middle";
-                        y = plotOffset.top + axis.p2c(tick.v);
-                        if (axis.position == "left") {
-                            x = box.left + box.width - box.padding;
-                            halign = "right";
-                        } else {
-                            x = box.left + box.padding;
-                        }
-                    }
-
-                    surface.addText(layer, x, y, tick.label, font, null, null, halign, valign);
-                }
-            });
-        }
-
-        function drawSeries(series) {
-            if (series.lines.show)
-                drawSeriesLines(series);
-            if (series.bars.show)
-                drawSeriesBars(series);
-            if (series.points.show)
-                drawSeriesPoints(series);
-        }
-
-        function drawSeriesLines(series) {
-            function plotLine(datapoints, xoffset, yoffset, axisx, axisy) {
-                var points = datapoints.points,
-                    ps = datapoints.pointsize,
-                    prevx = null, prevy = null;
-
-                ctx.beginPath();
-                for (var i = ps; i < points.length; i += ps) {
-                    var x1 = points[i - ps], y1 = points[i - ps + 1],
-                        x2 = points[i], y2 = points[i + 1];
-
-                    if (x1 == null || x2 == null)
-                        continue;
-
-                    // clip with ymin
-                    if (y1 <= y2 && y1 < axisy.min) {
-                        if (y2 < axisy.min)
-                            continue;   // line segment is outside
-                        // compute new intersection point
-                        x1 = (axisy.min - y1) / (y2 - y1) * (x2 - x1) + x1;
-                        y1 = axisy.min;
-                    }
-                    else if (y2 <= y1 && y2 < axisy.min) {
-                        if (y1 < axisy.min)
-                            continue;
-                        x2 = (axisy.min - y1) / (y2 - y1) * (x2 - x1) + x1;
-                        y2 = axisy.min;
-                    }
-
-                    // clip with ymax
-                    if (y1 >= y2 && y1 > axisy.max) {
-                        if (y2 > axisy.max)
-                            continue;
-                        x1 = (axisy.max - y1) / (y2 - y1) * (x2 - x1) + x1;
-                        y1 = axisy.max;
-                    }
-                    else if (y2 >= y1 && y2 > axisy.max) {
-                        if (y1 > axisy.max)
-                            continue;
-                        x2 = (axisy.max - y1) / (y2 - y1) * (x2 - x1) + x1;
-                        y2 = axisy.max;
-                    }
-
-                    // clip with xmin
-                    if (x1 <= x2 && x1 < axisx.min) {
-                        if (x2 < axisx.min)
-                            continue;
-                        y1 = (axisx.min - x1) / (x2 - x1) * (y2 - y1) + y1;
-                        x1 = axisx.min;
-                    }
-                    else if (x2 <= x1 && x2 < axisx.min) {
-                        if (x1 < axisx.min)
-                            continue;
-                        y2 = (axisx.min - x1) / (x2 - x1) * (y2 - y1) + y1;
-                        x2 = axisx.min;
-                    }
-
-                    // clip with xmax
-                    if (x1 >= x2 && x1 > axisx.max) {
-                        if (x2 > axisx.max)
-                            continue;
-                        y1 = (axisx.max - x1) / (x2 - x1) * (y2 - y1) + y1;
-                        x1 = axisx.max;
-                    }
-                    else if (x2 >= x1 && x2 > axisx.max) {
-                        if (x1 > axisx.max)
-                            continue;
-                        y2 = (axisx.max - x1) / (x2 - x1) * (y2 - y1) + y1;
-                        x2 = axisx.max;
-                    }
-
-                    if (x1 != prevx || y1 != prevy)
-                        ctx.moveTo(axisx.p2c(x1) + xoffset, axisy.p2c(y1) + yoffset);
-
-                    prevx = x2;
-                    prevy = y2;
-                    ctx.lineTo(axisx.p2c(x2) + xoffset, axisy.p2c(y2) + yoffset);
-                }
-                ctx.stroke();
-            }
-
-            function plotLineArea(datapoints, axisx, axisy) {
-                var points = datapoints.points,
-                    ps = datapoints.pointsize,
-                    bottom = Math.min(Math.max(0, axisy.min), axisy.max),
-                    i = 0, top, areaOpen = false,
-                    ypos = 1, segmentStart = 0, segmentEnd = 0;
-
-                // we process each segment in two turns, first forward
-                // direction to sketch out top, then once we hit the
-                // end we go backwards to sketch the bottom
-                while (true) {
-                    if (ps > 0 && i > points.length + ps)
-                        break;
-
-                    i += ps; // ps is negative if going backwards
-
-                    var x1 = points[i - ps],
-                        y1 = points[i - ps + ypos],
-                        x2 = points[i], y2 = points[i + ypos];
-
-                    if (areaOpen) {
-                        if (ps > 0 && x1 != null && x2 == null) {
-                            // at turning point
-                            segmentEnd = i;
-                            ps = -ps;
-                            ypos = 2;
-                            continue;
-                        }
-
-                        if (ps < 0 && i == segmentStart + ps) {
-                            // done with the reverse sweep
-                            ctx.fill();
-                            areaOpen = false;
-                            ps = -ps;
-                            ypos = 1;
-                            i = segmentStart = segmentEnd + ps;
-                            continue;
-                        }
-                    }
-
-                    if (x1 == null || x2 == null)
-                        continue;
-
-                    // clip x values
-
-                    // clip with xmin
-                    if (x1 <= x2 && x1 < axisx.min) {
-                        if (x2 < axisx.min)
-                            continue;
-                        y1 = (axisx.min - x1) / (x2 - x1) * (y2 - y1) + y1;
-                        x1 = axisx.min;
-                    }
-                    else if (x2 <= x1 && x2 < axisx.min) {
-                        if (x1 < axisx.min)
-                            continue;
-                        y2 = (axisx.min - x1) / (x2 - x1) * (y2 - y1) + y1;
-                        x2 = axisx.min;
-                    }
-
-                    // clip with xmax
-                    if (x1 >= x2 && x1 > axisx.max) {
-                        if (x2 > axisx.max)
-                            continue;
-                        y1 = (axisx.max - x1) / (x2 - x1) * (y2 - y1) + y1;
-                        x1 = axisx.max;
-                    }
-                    else if (x2 >= x1 && x2 > axisx.max) {
-                        if (x1 > axisx.max)
-                            continue;
-                        y2 = (axisx.max - x1) / (x2 - x1) * (y2 - y1) + y1;
-                        x2 = axisx.max;
-                    }
-
-                    if (!areaOpen) {
-                        // open area
-                        ctx.beginPath();
-                        ctx.moveTo(axisx.p2c(x1), axisy.p2c(bottom));
-                        areaOpen = true;
-                    }
-
-                    // now first check the case where both is outside
-                    if (y1 >= axisy.max && y2 >= axisy.max) {
-                        ctx.lineTo(axisx.p2c(x1), axisy.p2c(axisy.max));
-                        ctx.lineTo(axisx.p2c(x2), axisy.p2c(axisy.max));
-                        continue;
-                    }
-                    else if (y1 <= axisy.min && y2 <= axisy.min) {
-                        ctx.lineTo(axisx.p2c(x1), axisy.p2c(axisy.min));
-                        ctx.lineTo(axisx.p2c(x2), axisy.p2c(axisy.min));
-                        continue;
-                    }
-
-                    // else it's a bit more complicated, there might
-                    // be a flat maxed out rectangle first, then a
-                    // triangular cutout or reverse; to find these
-                    // keep track of the current x values
-                    var x1old = x1, x2old = x2;
-
-                    // clip the y values, without shortcutting, we
-                    // go through all cases in turn
-
-                    // clip with ymin
-                    if (y1 <= y2 && y1 < axisy.min && y2 >= axisy.min) {
-                        x1 = (axisy.min - y1) / (y2 - y1) * (x2 - x1) + x1;
-                        y1 = axisy.min;
-                    }
-                    else if (y2 <= y1 && y2 < axisy.min && y1 >= axisy.min) {
-                        x2 = (axisy.min - y1) / (y2 - y1) * (x2 - x1) + x1;
-                        y2 = axisy.min;
-                    }
-
-                    // clip with ymax
-                    if (y1 >= y2 && y1 > axisy.max && y2 <= axisy.max) {
-                        x1 = (axisy.max - y1) / (y2 - y1) * (x2 - x1) + x1;
-                        y1 = axisy.max;
-                    }
-                    else if (y2 >= y1 && y2 > axisy.max && y1 <= axisy.max) {
-                        x2 = (axisy.max - y1) / (y2 - y1) * (x2 - x1) + x1;
-                        y2 = axisy.max;
-                    }
-
-                    // if the x value was changed we got a rectangle
-                    // to fill
-                    if (x1 != x1old) {
-                        ctx.lineTo(axisx.p2c(x1old), axisy.p2c(y1));
-                        // it goes to (x1, y1), but we fill that below
-                    }
-
-                    // fill triangular section, this sometimes result
-                    // in redundant points if (x1, y1) hasn't changed
-                    // from previous line to, but we just ignore that
-                    ctx.lineTo(axisx.p2c(x1), axisy.p2c(y1));
-                    ctx.lineTo(axisx.p2c(x2), axisy.p2c(y2));
-
-                    // fill the other rectangle if it's there
-                    if (x2 != x2old) {
-                        ctx.lineTo(axisx.p2c(x2), axisy.p2c(y2));
-                        ctx.lineTo(axisx.p2c(x2old), axisy.p2c(y2));
-                    }
-                }
-            }
-
-            ctx.save();
-            ctx.translate(plotOffset.left, plotOffset.top);
-            ctx.lineJoin = "round";
-
-            var lw = series.lines.lineWidth,
-                sw = series.shadowSize;
-            // FIXME: consider another form of shadow when filling is turned on
-            if (lw > 0 && sw > 0) {
-                // draw shadow as a thick and thin line with transparency
-                ctx.lineWidth = sw;
-                ctx.strokeStyle = "rgba(0,0,0,0.1)";
-                // position shadow at angle from the mid of line
-                var angle = Math.PI/18;
-                plotLine(series.datapoints, Math.sin(angle) * (lw/2 + sw/2), Math.cos(angle) * (lw/2 + sw/2), series.xaxis, series.yaxis);
-                ctx.lineWidth = sw/2;
-                plotLine(series.datapoints, Math.sin(angle) * (lw/2 + sw/4), Math.cos(angle) * (lw/2 + sw/4), series.xaxis, series.yaxis);
-            }
-
-            ctx.lineWidth = lw;
-            ctx.strokeStyle = series.color;
-            var fillStyle = getFillStyle(series.lines, series.color, 0, plotHeight);
-            if (fillStyle) {
-                ctx.fillStyle = fillStyle;
-                plotLineArea(series.datapoints, series.xaxis, series.yaxis);
-            }
-
-            if (lw > 0)
-                plotLine(series.datapoints, 0, 0, series.xaxis, series.yaxis);
-            ctx.restore();
-        }
-
-        function drawSeriesPoints(series) {
-            function plotPoints(datapoints, radius, fillStyle, offset, shadow, axisx, axisy, symbol) {
-                var points = datapoints.points, ps = datapoints.pointsize;
-
-                for (var i = 0; i < points.length; i += ps) {
-                    var x = points[i], y = points[i + 1];
-                    if (x == null || x < axisx.min || x > axisx.max || y < axisy.min || y > axisy.max)
-                        continue;
-
-                    ctx.beginPath();
-                    x = axisx.p2c(x);
-                    y = axisy.p2c(y) + offset;
-                    if (symbol == "circle")
-                        ctx.arc(x, y, radius, 0, shadow ? Math.PI : Math.PI * 2, false);
-                    else
-                        symbol(ctx, x, y, radius, shadow);
-                    ctx.closePath();
-
-                    if (fillStyle) {
-                        ctx.fillStyle = fillStyle;
-                        ctx.fill();
-                    }
-                    ctx.stroke();
-                }
-            }
-
-            ctx.save();
-            ctx.translate(plotOffset.left, plotOffset.top);
-
-            var lw = series.points.lineWidth,
-                sw = series.shadowSize,
-                radius = series.points.radius,
-                symbol = series.points.symbol;
-
-            // If the user sets the line width to 0, we change it to a very 
-            // small value. A line width of 0 seems to force the default of 1.
-            // Doing the conditional here allows the shadow setting to still be 
-            // optional even with a lineWidth of 0.
-
-            if( lw == 0 )
-                lw = 0.0001;
-
-            if (lw > 0 && sw > 0) {
-                // draw shadow in two steps
-                var w = sw / 2;
-                ctx.lineWidth = w;
-                ctx.strokeStyle = "rgba(0,0,0,0.1)";
-                plotPoints(series.datapoints, radius, null, w + w/2, true,
-                           series.xaxis, series.yaxis, symbol);
-
-                ctx.strokeStyle = "rgba(0,0,0,0.2)";
-                plotPoints(series.datapoints, radius, null, w/2, true,
-                           series.xaxis, series.yaxis, symbol);
-            }
-
-            ctx.lineWidth = lw;
-            ctx.strokeStyle = series.color;
-            plotPoints(series.datapoints, radius,
-                       getFillStyle(series.points, series.color), 0, false,
-                       series.xaxis, series.yaxis, symbol);
-            ctx.restore();
-        }
-
-        function drawBar(x, y, b, barLeft, barRight, fillStyleCallback, axisx, axisy, c, horizontal, lineWidth) {
-            var left, right, bottom, top,
-                drawLeft, drawRight, drawTop, drawBottom,
-                tmp;
-
-            // in horizontal mode, we start the bar from the left
-            // instead of from the bottom so it appears to be
-            // horizontal rather than vertical
-            if (horizontal) {
-                drawBottom = drawRight = drawTop = true;
-                drawLeft = false;
-                left = b;
-                right = x;
-                top = y + barLeft;
-                bottom = y + barRight;
-
-                // account for negative bars
-                if (right < left) {
-                    tmp = right;
-                    right = left;
-                    left = tmp;
-                    drawLeft = true;
-                    drawRight = false;
-                }
-            }
-            else {
-                drawLeft = drawRight = drawTop = true;
-                drawBottom = false;
-                left = x + barLeft;
-                right = x + barRight;
-                bottom = b;
-                top = y;
-
-                // account for negative bars
-                if (top < bottom) {
-                    tmp = top;
-                    top = bottom;
-                    bottom = tmp;
-                    drawBottom = true;
-                    drawTop = false;
-                }
-            }
-
-            // clip
-            if (right < axisx.min || left > axisx.max ||
-                top < axisy.min || bottom > axisy.max)
-                return;
-
-            if (left < axisx.min) {
-                left = axisx.min;
-                drawLeft = false;
-            }
-
-            if (right > axisx.max) {
-                right = axisx.max;
-                drawRight = false;
-            }
-
-            if (bottom < axisy.min) {
-                bottom = axisy.min;
-                drawBottom = false;
-            }
-
-            if (top > axisy.max) {
-                top = axisy.max;
-                drawTop = false;
-            }
-
-            left = axisx.p2c(left);
-            bottom = axisy.p2c(bottom);
-            right = axisx.p2c(right);
-            top = axisy.p2c(top);
-
-            // fill the bar
-            if (fillStyleCallback) {
-                c.fillStyle = fillStyleCallback(bottom, top);
-                c.fillRect(left, top, right - left, bottom - top)
-            }
-
-            // draw outline
-            if (lineWidth > 0 && (drawLeft || drawRight || drawTop || drawBottom)) {
-                c.beginPath();
-
-                // FIXME: inline moveTo is buggy with excanvas
-                c.moveTo(left, bottom);
-                if (drawLeft)
-                    c.lineTo(left, top);
-                else
-                    c.moveTo(left, top);
-                if (drawTop)
-                    c.lineTo(right, top);
-                else
-                    c.moveTo(right, top);
-                if (drawRight)
-                    c.lineTo(right, bottom);
-                else
-                    c.moveTo(right, bottom);
-                if (drawBottom)
-                    c.lineTo(left, bottom);
-                else
-                    c.moveTo(left, bottom);
-                c.stroke();
-            }
-        }
-
-        function drawSeriesBars(series) {
-            function plotBars(datapoints, barLeft, barRight, fillStyleCallback, axisx, axisy) {
-                var points = datapoints.points, ps = datapoints.pointsize;
-
-                for (var i = 0; i < points.length; i += ps) {
-                    if (points[i] == null)
-                        continue;
-                    drawBar(points[i], points[i + 1], points[i + 2], barLeft, barRight, fillStyleCallback, axisx, axisy, ctx, series.bars.horizontal, series.bars.lineWidth);
-                }
-            }
-
-            ctx.save();
-            ctx.translate(plotOffset.left, plotOffset.top);
-
-            // FIXME: figure out a way to add shadows (for instance along the right edge)
-            ctx.lineWidth = series.bars.lineWidth;
-            ctx.strokeStyle = series.color;
-
-            var barLeft;
-
-            switch (series.bars.align) {
-                case "left":
-                    barLeft = 0;
-                    break;
-                case "right":
-                    barLeft = -series.bars.barWidth;
-                    break;
-                default:
-                    barLeft = -series.bars.barWidth / 2;
-            }
-
-            var fillStyleCallback = series.bars.fill ? function (bottom, top) { return getFillStyle(series.bars, series.color, bottom, top); } : null;
-            plotBars(series.datapoints, barLeft, barLeft + series.bars.barWidth, fillStyleCallback, series.xaxis, series.yaxis);
-            ctx.restore();
-        }
-
-        function getFillStyle(filloptions, seriesColor, bottom, top) {
-            var fill = filloptions.fill;
-            if (!fill)
-                return null;
-
-            if (filloptions.fillColor)
-                return getColorOrGradient(filloptions.fillColor, bottom, top, seriesColor);
-
-            var c = $.color.parse(seriesColor);
-            c.a = typeof fill == "number" ? fill : 0.4;
-            c.normalize();
-            return c.toString();
-        }
-
-        function insertLegend() {
-
-            if (options.legend.container != null) {
-                $(options.legend.container).html("");
-            } else {
-                placeholder.find(".legend").remove();
-            }
-
-            if (!options.legend.show) {
-                return;
-            }
-
-            var fragments = [], entries = [], rowStarted = false,
-                lf = options.legend.labelFormatter, s, label;
-
-            // Build a list of legend entries, with each having a label and a color
-
-            for (var i = 0; i < series.length; ++i) {
-                s = series[i];
-                if (s.label) {
-                    label = lf ? lf(s.label, s) : s.label;
-                    if (label) {
-                        entries.push({
-                            label: label,
-                            color: s.color
-                        });
-                    }
-                }
-            }
-
-            // Sort the legend using either the default or a custom comparator
-
-            if (options.legend.sorted) {
-                if ($.isFunction(options.legend.sorted)) {
-                    entries.sort(options.legend.sorted);
-                } else if (options.legend.sorted == "reverse") {
-                	entries.reverse();
-                } else {
-                    var ascending = options.legend.sorted != "descending";
-                    entries.sort(function(a, b) {
-                        return a.label == b.label ? 0 : (
-                            (a.label < b.label) != ascending ? 1 : -1   // Logical XOR
-                        );
-                    });
-                }
-            }
-
-            // Generate markup for the list of entries, in their final order
-
-            for (var i = 0; i < entries.length; ++i) {
-
-                var entry = entries[i];
-
-                if (i % options.legend.noColumns == 0) {
-                    if (rowStarted)
-                        fragments.push('</tr>');
-                    fragments.push('<tr>');
-                    rowStarted = true;
-                }
-
-                fragments.push(
-                    '<td class="legendColorBox"><div style="border:1px solid ' + options.legend.labelBoxBorderColor + ';padding:1px"><div style="width:4px;height:0;border:5px solid ' + entry.color + ';overflow:hidden"></div></div></td>' +
-                    '<td class="legendLabel">' + entry.label + '</td>'
-                );
-            }
-
-            if (rowStarted)
-                fragments.push('</tr>');
-
-            if (fragments.length == 0)
-                return;
-
-            var table = '<table style="font-size:smaller;color:' + options.grid.color + '">' + fragments.join("") + '</table>';
-            if (options.legend.container != null)
-                $(options.legend.container).html(table);
-            else {
-                var pos = "",
-                    p = options.legend.position,
-                    m = options.legend.margin;
-                if (m[0] == null)
-                    m = [m, m];
-                if (p.charAt(0) == "n")
-                    pos += 'top:' + (m[1] + plotOffset.top) + 'px;';
-                else if (p.charAt(0) == "s")
-                    pos += 'bottom:' + (m[1] + plotOffset.bottom) + 'px;';
-                if (p.charAt(1) == "e")
-                    pos += 'right:' + (m[0] + plotOffset.right) + 'px;';
-                else if (p.charAt(1) == "w")
-                    pos += 'left:' + (m[0] + plotOffset.left) + 'px;';
-                var legend = $('<div class="legend">' + table.replace('style="', 'style="position:absolute;' + pos +';') + '</div>').appendTo(placeholder);
-                if (options.legend.backgroundOpacity != 0.0) {
-                    // put in the transparent background
-                    // separately to avoid blended labels and
-                    // label boxes
-                    var c = options.legend.backgroundColor;
-                    if (c == null) {
-                        c = options.grid.backgroundColor;
-                        if (c && typeof c == "string")
-                            c = $.color.parse(c);
-                        else
-                            c = $.color.extract(legend, 'background-color');
-                        c.a = 1;
-                        c = c.toString();
-                    }
-                    var div = legend.children();
-                    $('<div style="position:absolute;width:' + div.width() + 'px;height:' + div.height() + 'px;' + pos +'background-color:' + c + ';"> </div>').prependTo(legend).css('opacity', options.legend.backgroundOpacity);
-                }
-            }
-        }
-
-
-        // interactive features
-
-        var highlights = [],
-            redrawTimeout = null;
-
-        // returns the data item the mouse is over, or null if none is found
-        function findNearbyItem(mouseX, mouseY, seriesFilter) {
-            var maxDistance = options.grid.mouseActiveRadius,
-                smallestDistance = maxDistance * maxDistance + 1,
-                item = null, foundPoint = false, i, j, ps;
-
-            for (i = series.length - 1; i >= 0; --i) {
-                if (!seriesFilter(series[i]))
-                    continue;
-
-                var s = series[i],
-                    axisx = s.xaxis,
-                    axisy = s.yaxis,
-                    points = s.datapoints.points,
-                    mx = axisx.c2p(mouseX), // precompute some stuff to make the loop faster
-                    my = axisy.c2p(mouseY),
-                    maxx = maxDistance / axisx.scale,
-                    maxy = maxDistance / axisy.scale;
-
-                ps = s.datapoints.pointsize;
-                // with inverse transforms, we can't use the maxx/maxy
-                // optimization, sadly
-                if (axisx.options.inverseTransform)
-                    maxx = Number.MAX_VALUE;
-                if (axisy.options.inverseTransform)
-                    maxy = Number.MAX_VALUE;
-
-                if (s.lines.show || s.points.show) {
-                    for (j = 0; j < points.length; j += ps) {
-                        var x = points[j], y = points[j + 1];
-                        if (x == null)
-                            continue;
-
-                        // For points and lines, the cursor must be within a
-                        // certain distance to the data point
-                        if (x - mx > maxx || x - mx < -maxx ||
-                            y - my > maxy || y - my < -maxy)
-                            continue;
-
-                        // We have to calculate distances in pixels, not in
-                        // data units, because the scales of the axes may be different
-                        var dx = Math.abs(axisx.p2c(x) - mouseX),
-                            dy = Math.abs(axisy.p2c(y) - mouseY),
-                            dist = dx * dx + dy * dy; // we save the sqrt
-
-                        // use <= to ensure last point takes precedence
-                        // (last generally means on top of)
-                        if (dist < smallestDistance) {
-                            smallestDistance = dist;
-                            item = [i, j / ps];
-                        }
-                    }
-                }
-
-                if (s.bars.show && !item) { // no other point can be nearby
-
-                    var barLeft, barRight;
-
-                    switch (s.bars.align) {
-                        case "left":
-                            barLeft = 0;
-                            break;
-                        case "right":
-                            barLeft = -s.bars.barWidth;
-                            break;
-                        default:
-                            barLeft = -s.bars.barWidth / 2;
-                    }
-
-                    barRight = barLeft + s.bars.barWidth;
-
-                    for (j = 0; j < points.length; j += ps) {
-                        var x = points[j], y = points[j + 1], b = points[j + 2];
-                        if (x == null)
-                            continue;
-
-                        // for a bar graph, the cursor must be inside the bar
-                        if (series[i].bars.horizontal ?
-                            (mx <= Math.max(b, x) && mx >= Math.min(b, x) &&
-                             my >= y + barLeft && my <= y + barRight) :
-                            (mx >= x + barLeft && mx <= x + barRight &&
-                             my >= Math.min(b, y) && my <= Math.max(b, y)))
-                                item = [i, j / ps];
-                    }
-                }
-            }
-
-            if (item) {
-                i = item[0];
-                j = item[1];
-                ps = series[i].datapoints.pointsize;
-
-                return { datapoint: series[i].datapoints.points.slice(j * ps, (j + 1) * ps),
-                         dataIndex: j,
-                         series: series[i],
-                         seriesIndex: i };
-            }
-
-            return null;
-        }
-
-        function onMouseMove(e) {
-            if (options.grid.hoverable)
-                triggerClickHoverEvent("plothover", e,
-                                       function (s) { return s["hoverable"] != false; });
-        }
-
-        function onMouseLeave(e) {
-            if (options.grid.hoverable)
-                triggerClickHoverEvent("plothover", e,
-                                       function (s) { return false; });
-        }
-
-        function onClick(e) {
-            triggerClickHoverEvent("plotclick", e,
-                                   function (s) { return s["clickable"] != false; });
-        }
-
-        // trigger click or hover event (they send the same parameters
-        // so we share their code)
-        function triggerClickHoverEvent(eventname, event, seriesFilter) {
-            var offset = eventHolder.offset(),
-                canvasX = event.pageX - offset.left - plotOffset.left,
-                canvasY = event.pageY - offset.top - plotOffset.top,
-            pos = canvasToAxisCoords({ left: canvasX, top: canvasY });
-
-            pos.pageX = event.pageX;
-            pos.pageY = event.pageY;
-
-            var item = findNearbyItem(canvasX, canvasY, seriesFilter);
-
-            if (item) {
-                // fill in mouse pos for any listeners out there
-                item.pageX = parseInt(item.series.xaxis.p2c(item.datapoint[0]) + offset.left + plotOffset.left, 10);
-                item.pageY = parseInt(item.series.yaxis.p2c(item.datapoint[1]) + offset.top + plotOffset.top, 10);
-            }
-
-            if (options.grid.autoHighlight) {
-                // clear auto-highlights
-                for (var i = 0; i < highlights.length; ++i) {
-                    var h = highlights[i];
-                    if (h.auto == eventname &&
-                        !(item && h.series == item.series &&
-                          h.point[0] == item.datapoint[0] &&
-                          h.point[1] == item.datapoint[1]))
-                        unhighlight(h.series, h.point);
-                }
-
-                if (item)
-                    highlight(item.series, item.datapoint, eventname);
-            }
-
-            placeholder.trigger(eventname, [ pos, item ]);
-        }
-
-        function triggerRedrawOverlay() {
-            var t = options.interaction.redrawOverlayInterval;
-            if (t == -1) {      // skip event queue
-                drawOverlay();
-                return;
-            }
-
-            if (!redrawTimeout)
-                redrawTimeout = setTimeout(drawOverlay, t);
-        }
-
-        function drawOverlay() {
-            redrawTimeout = null;
-
-            // draw highlights
-            octx.save();
-            overlay.clear();
-            octx.translate(plotOffset.left, plotOffset.top);
-
-            var i, hi;
-            for (i = 0; i < highlights.length; ++i) {
-                hi = highlights[i];
-
-                if (hi.series.bars.show)
-                    drawBarHighlight(hi.series, hi.point);
-                else
-                    drawPointHighlight(hi.series, hi.point);
-            }
-            octx.restore();
-
-            executeHooks(hooks.drawOverlay, [octx]);
-        }
-
-        function highlight(s, point, auto) {
-            if (typeof s == "number")
-                s = series[s];
-
-            if (typeof point == "number") {
-                var ps = s.datapoints.pointsize;
-                point = s.datapoints.points.slice(ps * point, ps * (point + 1));
-            }
-
-            var i = indexOfHighlight(s, point);
-            if (i == -1) {
-                highlights.push({ series: s, point: point, auto: auto });
-
-                triggerRedrawOverlay();
-            }
-            else if (!auto)
-                highlights[i].auto = false;
-        }
-
-        function unhighlight(s, point) {
-            if (s == null && point == null) {
-                highlights = [];
-                triggerRedrawOverlay();
-                return;
-            }
-
-            if (typeof s == "number")
-                s = series[s];
-
-            if (typeof point == "number") {
-                var ps = s.datapoints.pointsize;
-                point = s.datapoints.points.slice(ps * point, ps * (point + 1));
-            }
-
-            var i = indexOfHighlight(s, point);
-            if (i != -1) {
-                highlights.splice(i, 1);
-
-                triggerRedrawOverlay();
-            }
-        }
-
-        function indexOfHighlight(s, p) {
-            for (var i = 0; i < highlights.length; ++i) {
-                var h = highlights[i];
-                if (h.series == s && h.point[0] == p[0]
-                    && h.point[1] == p[1])
-                    return i;
-            }
-            return -1;
-        }
-
-        function drawPointHighlight(series, point) {
-            var x = point[0], y = point[1],
-                axisx = series.xaxis, axisy = series.yaxis,
-                highlightColor = (typeof series.highlightColor === "string") ? series.highlightColor : $.color.parse(series.color).scale('a', 0.5).toString();
-
-            if (x < axisx.min || x > axisx.max || y < axisy.min || y > axisy.max)
-                return;
-
-            var pointRadius = series.points.radius + series.points.lineWidth / 2;
-            octx.lineWidth = pointRadius;
-            octx.strokeStyle = highlightColor;
-            var radius = 1.5 * pointRadius;
-            x = axisx.p2c(x);
-            y = axisy.p2c(y);
-
-            octx.beginPath();
-            if (series.points.symbol == "circle")
-                octx.arc(x, y, radius, 0, 2 * Math.PI, false);
-            else
-                series.points.symbol(octx, x, y, radius, false);
-            octx.closePath();
-            octx.stroke();
-        }
-
-        function drawBarHighlight(series, point) {
-            var highlightColor = (typeof series.highlightColor === "string") ? series.highlightColor : $.color.parse(series.color).scale('a', 0.5).toString(),
-                fillStyle = highlightColor,
-                barLeft;
-
-            switch (series.bars.align) {
-                case "left":
-                    barLeft = 0;
-                    break;
-                case "right":
-                    barLeft = -series.bars.barWidth;
-                    break;
-                default:
-                    barLeft = -series.bars.barWidth / 2;
-            }
-
-            octx.lineWidth = series.bars.lineWidth;
-            octx.strokeStyle = highlightColor;
-
-            drawBar(point[0], point[1], point[2] || 0, barLeft, barLeft + series.bars.barWidth,
-                    function () { return fillStyle; }, series.xaxis, series.yaxis, octx, series.bars.horizontal, series.bars.lineWidth);
-        }
-
-        function getColorOrGradient(spec, bottom, top, defaultColor) {
-            if (typeof spec == "string")
-                return spec;
-            else {
-                // assume this is a gradient spec; IE currently only
-                // supports a simple vertical gradient properly, so that's
-                // what we support too
-                var gradient = ctx.createLinearGradient(0, top, 0, bottom);
-
-                for (var i = 0, l = spec.colors.length; i < l; ++i) {
-                    var c = spec.colors[i];
-                    if (typeof c != "string") {
-                        var co = $.color.parse(defaultColor);
-                        if (c.brightness != null)
-                            co = co.scale('rgb', c.brightness);
-                        if (c.opacity != null)
-                            co.a *= c.opacity;
-                        c = co.toString();
-                    }
-                    gradient.addColorStop(i / (l - 1), c);
-                }
-
-                return gradient;
-            }
-        }
-    }
-
-    // Add the plot function to the top level of the jQuery object
-
-    $.plot = function(placeholder, data, options) {
-        //var t0 = new Date();
-        var plot = new Plot($(placeholder), data, options, $.plot.plugins);
-        //(window.console ? console.log : alert)("time used (msecs): " + ((new Date()).getTime() - t0.getTime()));
-        return plot;
-    };
-
-    $.plot.version = "0.8.3";
-
-    $.plot.plugins = [];
-
-    // Also add the plot function as a chainable property
-
-    $.fn.plot = function(data, options) {
-        return this.each(function() {
-            $.plot(this, data, options);
-        });
-    };
-
-    // round to nearby lower multiple of base
-    function floorInBase(n, base) {
-        return base * Math.floor(n / base);
-    }
+					return formatted;
+				};
+			}
+
+			if ($.isFunction(opts.tickFormatter))
+				axis.tickFormatter = function (v, axis) { return "" + opts.tickFormatter(v, axis); };
+
+			if (opts.alignTicksWithAxis != null) {
+				var otherAxis = (axis.direction == "x" ? xaxes : yaxes)[opts.alignTicksWithAxis - 1];
+				if (otherAxis && otherAxis.used && otherAxis != axis) {
+					// consider snapping min/max to outermost nice ticks
+					var niceTicks = axis.tickGenerator(axis);
+					if (niceTicks.length > 0) {
+						if (opts.min == null)
+							axis.min = Math.min(axis.min, niceTicks[0]);
+						if (opts.max == null && niceTicks.length > 1)
+							axis.max = Math.max(axis.max, niceTicks[niceTicks.length - 1]);
+					}
+
+					axis.tickGenerator = function (axis) {
+						// copy ticks, scaled to this axis
+						var ticks = [], v, i;
+						for (i = 0; i < otherAxis.ticks.length; ++i) {
+							v = (otherAxis.ticks[i].v - otherAxis.min) / (otherAxis.max - otherAxis.min);
+							v = axis.min + v * (axis.max - axis.min);
+							ticks.push(v);
+						}
+						return ticks;
+					};
+
+					// we might need an extra decimal since forced
+					// ticks don't necessarily fit naturally
+					if (!axis.mode && opts.tickDecimals == null) {
+						var extraDec = Math.max(0, -Math.floor(Math.log(axis.delta) / Math.LN10) + 1),
+							ts = axis.tickGenerator(axis);
+
+						// only proceed if the tick interval rounded
+						// with an extra decimal doesn't give us a
+						// zero at end
+						if (!(ts.length > 1 && /\..*0$/.test((ts[1] - ts[0]).toFixed(extraDec))))
+							axis.tickDecimals = extraDec;
+					}
+				}
+			}
+		}
+
+		function setTicks(axis) {
+			var oticks = axis.options.ticks, ticks = [];
+			if (oticks == null || (typeof oticks == "number" && oticks > 0))
+				ticks = axis.tickGenerator(axis);
+			else if (oticks) {
+				if ($.isFunction(oticks))
+					// generate the ticks
+					ticks = oticks(axis);
+				else
+					ticks = oticks;
+			}
+
+			// clean up/labelify the supplied ticks, copy them over
+			var i, v;
+			axis.ticks = [];
+			for (i = 0; i < ticks.length; ++i) {
+				var label = null;
+				var t = ticks[i];
+				if (typeof t == "object") {
+					v = +t[0];
+					if (t.length > 1)
+						label = t[1];
+				}
+				else
+					v = +t;
+				if (label == null)
+					label = axis.tickFormatter(v, axis);
+				if (!isNaN(v))
+					axis.ticks.push({ v: v, label: label });
+			}
+		}
+
+		function snapRangeToTicks(axis, ticks) {
+			if (axis.options.autoscaleMargin && ticks.length > 0) {
+				// snap to ticks
+				if (axis.options.min == null)
+					axis.min = Math.min(axis.min, ticks[0].v);
+				if (axis.options.max == null && ticks.length > 1)
+					axis.max = Math.max(axis.max, ticks[ticks.length - 1].v);
+			}
+		}
+
+		function draw() {
+
+			surface.clear();
+
+			executeHooks(hooks.drawBackground, [ctx]);
+
+			var grid = options.grid;
+
+			// draw background, if any
+			if (grid.show && grid.backgroundColor)
+				drawBackground();
+
+			if (grid.show && !grid.aboveData) {
+				drawGrid();
+			}
+			if (grid.show && !grid.axisAboveData) {
+				drawAxisBackground();
+				drawAxisLabels();
+			}
+
+			for (var i = 0; i < series.length; ++i) {
+				executeHooks(hooks.drawSeries, [ctx, series[i]]);
+				drawSeries(series[i]);
+			}
+
+			executeHooks(hooks.draw, [ctx]);
+
+			if (grid.show && grid.aboveData) {
+				drawGrid();
+			}
+			if (grid.show && grid.axisAboveData) {
+				drawAxisBackground();
+				drawAxisLabels();
+			}
+
+			surface.render();
+
+			// A draw implies that either the axes or data have changed, so we
+			// should probably update the overlay highlights as well.
+
+			triggerRedrawOverlay();
+		}
+
+		function extractRange(ranges, coord) {
+			var axis, from, to, key, axes = allAxes();
+
+			for (var i = 0; i < axes.length; ++i) {
+				axis = axes[i];
+				if (axis.direction == coord) {
+					key = coord + axis.n + "axis";
+					if (!ranges[key] && axis.n == 1)
+						key = coord + "axis"; // support x1axis as xaxis
+					if (ranges[key]) {
+						from = ranges[key].from;
+						to = ranges[key].to;
+						break;
+					}
+				}
+			}
+
+			// backwards-compat stuff - to be removed in future
+			if (!ranges[key]) {
+				axis = coord == "x" ? xaxes[0] : yaxes[0];
+				from = ranges[coord + "1"];
+				to = ranges[coord + "2"];
+			}
+
+			// auto-reverse as an added bonus
+			if (from != null && to != null && from > to) {
+				var tmp = from;
+				from = to;
+				to = tmp;
+			}
+
+			return { from: from, to: to, axis: axis };
+		}
+
+		function drawBackground() {
+			ctx.save();
+			ctx.translate(plotOffset.left, plotOffset.top);
+
+			ctx.fillStyle = getColorOrGradient(options.grid.backgroundColor, plotHeight, 0, "rgba(255, 255, 255, 0)");
+			ctx.fillRect(0, 0, plotWidth, plotHeight);
+			ctx.restore();
+		}
+
+		function drawGrid() {
+			var i, axes, bw, bc;
+
+			ctx.save();
+			ctx.translate(plotOffset.left, plotOffset.top);
+
+			// draw markings
+			var markings = options.grid.markings;
+			if (markings) {
+				if ($.isFunction(markings)) {
+					axes = plot.getAxes();
+					// xmin etc. is backwards compatibility, to be
+					// removed in the future
+					axes.xmin = axes.xaxis.min;
+					axes.xmax = axes.xaxis.max;
+					axes.ymin = axes.yaxis.min;
+					axes.ymax = axes.yaxis.max;
+
+					markings = markings(axes);
+				}
+
+				for (i = 0; i < markings.length; ++i) {
+					var m = markings[i],
+						xrange = extractRange(m, "x"),
+						yrange = extractRange(m, "y");
+
+					// fill in missing
+					if (xrange.from == null)
+						xrange.from = xrange.axis.min;
+					if (xrange.to == null)
+						xrange.to = xrange.axis.max;
+					if (yrange.from == null)
+						yrange.from = yrange.axis.min;
+					if (yrange.to == null)
+						yrange.to = yrange.axis.max;
+
+					// clip
+					if (xrange.to < xrange.axis.min || xrange.from > xrange.axis.max ||
+						yrange.to < yrange.axis.min || yrange.from > yrange.axis.max)
+						continue;
+
+					xrange.from = Math.max(xrange.from, xrange.axis.min);
+					xrange.to = Math.min(xrange.to, xrange.axis.max);
+					yrange.from = Math.max(yrange.from, yrange.axis.min);
+					yrange.to = Math.min(yrange.to, yrange.axis.max);
+
+					var xequal = xrange.from === xrange.to,
+						yequal = yrange.from === yrange.to;
+
+					if (xequal && yequal) {
+						continue;
+					}
+
+					// then draw
+					xrange.from = Math.floor(xrange.axis.p2c(xrange.from));
+					xrange.to = Math.floor(xrange.axis.p2c(xrange.to));
+					yrange.from = Math.floor(yrange.axis.p2c(yrange.from));
+					yrange.to = Math.floor(yrange.axis.p2c(yrange.to));
+
+					if (xequal || yequal) {
+						var lineWidth = m.lineWidth || options.grid.markingsLineWidth,
+							subPixel = lineWidth % 2 ? 0.5 : 0;
+						ctx.beginPath();
+						ctx.strokeStyle = m.color || options.grid.markingsColor;
+						ctx.lineWidth = lineWidth;
+						if (xequal) {
+							ctx.moveTo(xrange.to + subPixel, yrange.from);
+							ctx.lineTo(xrange.to + subPixel, yrange.to);
+						} else {
+							ctx.moveTo(xrange.from, yrange.to + subPixel);
+							ctx.lineTo(xrange.to, yrange.to + subPixel);
+						}
+						ctx.stroke();
+					} else {
+						ctx.fillStyle = m.color || options.grid.markingsColor;
+						ctx.fillRect(xrange.from, yrange.to,
+									 xrange.to - xrange.from,
+									 yrange.from - yrange.to);
+					}
+				}
+			}
+
+			// draw the ticks
+			axes = allAxes();
+			bw = options.grid.borderWidth;
+
+			for (var j = 0; j < axes.length; ++j) {
+				var axis = axes[j], box = axis.box,
+					t = axis.tickLength, x, y, xoff, yoff;
+				if (!axis.show || axis.ticks.length == 0)
+					continue;
+
+				ctx.lineWidth = 1;
+
+				// find the edges
+				if (axis.direction == "x") {
+					x = 0;
+					if (t == "full")
+						y = (axis.position == "top" ? 0 : plotHeight);
+					else
+						y = box.top - plotOffset.top + (axis.position == "top" ? box.height : 0);
+				}
+				else {
+					y = 0;
+					if (t == "full")
+						x = (axis.position == "left" ? 0 : plotWidth);
+					else
+						x = box.left - plotOffset.left + (axis.position == "left" ? box.width : 0);
+				}
+
+				// draw tick bar
+				if (!axis.innermost) {
+					ctx.strokeStyle = axis.options.color;
+					ctx.beginPath();
+					xoff = yoff = 0;
+					if (axis.direction == "x")
+						xoff = plotWidth + 1;
+					else
+						yoff = plotHeight + 1;
+
+					if (ctx.lineWidth == 1) {
+						if (axis.direction == "x") {
+							y = Math.floor(y) + 0.5;
+						} else {
+							x = Math.floor(x) + 0.5;
+						}
+					}
+
+					ctx.moveTo(x, y);
+					ctx.lineTo(x + xoff, y + yoff);
+					ctx.stroke();
+				}
+
+				// draw ticks
+
+				ctx.strokeStyle = axis.options.tickColor;
+
+				ctx.beginPath();
+				for (i = 0; i < axis.ticks.length; ++i) {
+					var v = axis.ticks[i].v;
+
+					xoff = yoff = 0;
+
+					if (isNaN(v) || v < axis.min || v > axis.max
+						// skip those lying on the axes if we got a border
+						|| (t == "full"
+							&& ((typeof bw == "object" && bw[axis.position] > 0) || bw > 0)
+							&& (v == axis.min || v == axis.max)))
+						continue;
+
+					if (axis.direction == "x") {
+						x = axis.p2c(v);
+						yoff = t == "full" ? -plotHeight : t;
+
+						if (axis.position == "top")
+							yoff = -yoff;
+					}
+					else {
+						y = axis.p2c(v);
+						xoff = t == "full" ? -plotWidth : t;
+
+						if (axis.position == "left")
+							xoff = -xoff;
+					}
+
+					if (ctx.lineWidth == 1) {
+						if (axis.direction == "x")
+							x = Math.floor(x) + 0.5;
+						else
+							y = Math.floor(y) + 0.5;
+					}
+
+					ctx.moveTo(x, y);
+					ctx.lineTo(x + xoff, y + yoff);
+				}
+
+				ctx.stroke();
+			}
+
+
+			// draw border
+			if (bw) {
+				// If either borderWidth or borderColor is an object, then draw the border
+				// line by line instead of as one rectangle
+				bc = options.grid.borderColor;
+				if(typeof bw == "object" || typeof bc == "object") {
+					if (typeof bw !== "object") {
+						bw = {top: bw, right: bw, bottom: bw, left: bw};
+					}
+					if (typeof bc !== "object") {
+						bc = {top: bc, right: bc, bottom: bc, left: bc};
+					}
+
+					if (bw.top > 0) {
+						ctx.strokeStyle = bc.top;
+						ctx.lineWidth = bw.top;
+						ctx.beginPath();
+						ctx.moveTo(0 - bw.left, 0 - bw.top/2);
+						ctx.lineTo(plotWidth, 0 - bw.top/2);
+						ctx.stroke();
+					}
+
+					if (bw.right > 0) {
+						ctx.strokeStyle = bc.right;
+						ctx.lineWidth = bw.right;
+						ctx.beginPath();
+						ctx.moveTo(plotWidth + bw.right / 2, 0 - bw.top);
+						ctx.lineTo(plotWidth + bw.right / 2, plotHeight);
+						ctx.stroke();
+					}
+
+					if (bw.bottom > 0) {
+						ctx.strokeStyle = bc.bottom;
+						ctx.lineWidth = bw.bottom;
+						ctx.beginPath();
+						ctx.moveTo(plotWidth + bw.right, plotHeight + bw.bottom / 2);
+						ctx.lineTo(0, plotHeight + bw.bottom / 2);
+						ctx.stroke();
+					}
+
+					if (bw.left > 0) {
+						ctx.strokeStyle = bc.left;
+						ctx.lineWidth = bw.left;
+						ctx.beginPath();
+						ctx.moveTo(0 - bw.left/2, plotHeight + bw.bottom);
+						ctx.lineTo(0- bw.left/2, 0);
+						ctx.stroke();
+					}
+				}
+				else {
+					ctx.lineWidth = bw;
+					ctx.strokeStyle = options.grid.borderColor;
+					ctx.strokeRect(-bw/2, -bw/2, plotWidth + bw, plotHeight + bw);
+				}
+			}
+
+			ctx.restore();
+		}
+
+		function drawAxisBackground() {
+			ctx.save();
+			ctx.translate(plotOffset.left, plotOffset.top);
+
+			// draw axis background
+			$.each(allAxes(), function (_, axis) {
+				var box = axis.box;
+				if (!(axis.show && axis.options.background))
+					return;
+
+				ctx.fillStyle = axis.options.background;
+				ctx.fillRect(box.left, box.top, box.width, box.height);
+			});
+
+			ctx.restore();
+		}
+
+		function drawAxisLabels() {
+
+			$.each(allAxes(), function (_, axis) {
+				var box = axis.box,
+					legacyStyles = axis.direction + "Axis " + axis.direction + axis.n + "Axis",
+					layer = "flot-" + axis.direction + "-axis flot-" + axis.direction + axis.n + "-axis " + legacyStyles,
+					font = axis.options.font || "flot-tick-label tickLabel",
+					background = (axis.options.font || {}).background,
+					tick, x, y, halign, valign;
+
+				// Remove text before checking for axis.show and ticks.length;
+				// otherwise plugins, like flot-tickrotor, that draw their own
+				// tick labels will end up with both theirs and the defaults.
+
+				surface.removeText(layer);
+
+				if (!axis.show || axis.ticks.length == 0)
+					return;
+
+				// label background
+				ctx.fillStyle = background;
+
+				for (var i = 0; i < axis.ticks.length; ++i) {
+
+					tick = axis.ticks[i];
+					if (!tick.label || tick.v < axis.min || tick.v > axis.max)
+						continue;
+
+					var pos = axis.p2c(tick.v);
+
+					if (axis.direction == "x") {
+						// omit outer labels
+						if (axis.options.labelPosition == "inside" &&
+							(pos < plotOffset.left + axis.labelWidth || pos > surface.width - plotOffset.right - axis.labelWidth)
+						) {
+							continue;
+						}
+
+						halign = "center";
+						x = plotOffset.left + pos;
+
+						// label background
+						if (background) {
+							ctx.fillRect(x - axis.labelWidth/2 - box.padding, box.top,
+								axis.labelWidth + 2*box.padding, axis.labelHeight + 2*box.padding);
+						}
+
+						if (axis.position == "bottom") {
+							y = box.top + box.padding;
+						} else {
+							y = box.top + box.height - box.padding;
+							valign = "bottom";
+						}
+					} else {
+						// omit outer labels
+						if (axis.options.labelPosition == "inside" &&
+							(pos < plotOffset.top + axis.labelHeight || pos > surface.height - plotOffset.bottom - axis.labelHeight)
+						) {
+							continue;
+						}
+
+						valign = "middle";
+						y = plotOffset.top + pos;
+
+						// label background
+						if (background) {
+							ctx.fillRect(box.left, y - axis.labelHeight/2 - box.padding,
+								axis.labelWidth + 2*box.padding, axis.labelHeight + 2*box.padding);
+						}
+
+						if (axis.position == "left") {
+							x = box.left + box.width - box.padding;
+							halign = "right";
+						} else {
+							x = box.left + box.padding;
+						}
+					}
+
+					surface.addText(layer, x, y, tick.label, font, null, null, halign, valign);
+				}
+			});
+		}
+
+		function drawSeries(series) {
+			if (series.lines.show)
+				drawSeriesLines(series);
+			if (series.bars.show)
+				drawSeriesBars(series);
+			if (series.points.show)
+				drawSeriesPoints(series);
+		}
+
+		function drawSeriesLines(series) {
+			function plotLine(datapoints, xoffset, yoffset, axisx, axisy) {
+				var points = datapoints.points,
+					ps = datapoints.pointsize,
+					prevx = null, prevy = null;
+
+				ctx.beginPath();
+				for (var i = ps; i < points.length; i += ps) {
+					var x1 = points[i - ps], y1 = points[i - ps + 1],
+						x2 = points[i], y2 = points[i + 1];
+
+					if (x1 == null || x2 == null)
+						continue;
+
+					// clip with ymin
+					if (y1 <= y2 && y1 < axisy.min) {
+						if (y2 < axisy.min)
+							continue;   // line segment is outside
+						// compute new intersection point
+						x1 = (axisy.min - y1) / (y2 - y1) * (x2 - x1) + x1;
+						y1 = axisy.min;
+					}
+					else if (y2 <= y1 && y2 < axisy.min) {
+						if (y1 < axisy.min)
+							continue;
+						x2 = (axisy.min - y1) / (y2 - y1) * (x2 - x1) + x1;
+						y2 = axisy.min;
+					}
+
+					// clip with ymax
+					if (y1 >= y2 && y1 > axisy.max) {
+						if (y2 > axisy.max)
+							continue;
+						x1 = (axisy.max - y1) / (y2 - y1) * (x2 - x1) + x1;
+						y1 = axisy.max;
+					}
+					else if (y2 >= y1 && y2 > axisy.max) {
+						if (y1 > axisy.max)
+							continue;
+						x2 = (axisy.max - y1) / (y2 - y1) * (x2 - x1) + x1;
+						y2 = axisy.max;
+					}
+
+					// clip with xmin
+					if (x1 <= x2 && x1 < axisx.min) {
+						if (x2 < axisx.min)
+							continue;
+						y1 = (axisx.min - x1) / (x2 - x1) * (y2 - y1) + y1;
+						x1 = axisx.min;
+					}
+					else if (x2 <= x1 && x2 < axisx.min) {
+						if (x1 < axisx.min)
+							continue;
+						y2 = (axisx.min - x1) / (x2 - x1) * (y2 - y1) + y1;
+						x2 = axisx.min;
+					}
+
+					// clip with xmax
+					if (x1 >= x2 && x1 > axisx.max) {
+						if (x2 > axisx.max)
+							continue;
+						y1 = (axisx.max - x1) / (x2 - x1) * (y2 - y1) + y1;
+						x1 = axisx.max;
+					}
+					else if (x2 >= x1 && x2 > axisx.max) {
+						if (x1 > axisx.max)
+							continue;
+						y2 = (axisx.max - x1) / (x2 - x1) * (y2 - y1) + y1;
+						x2 = axisx.max;
+					}
+
+					if (x1 != prevx || y1 != prevy)
+						ctx.moveTo(axisx.p2c(x1) + xoffset, axisy.p2c(y1) + yoffset);
+
+					prevx = x2;
+					prevy = y2;
+					ctx.lineTo(axisx.p2c(x2) + xoffset, axisy.p2c(y2) + yoffset);
+				}
+				ctx.stroke();
+			}
+
+			function plotLineArea(datapoints, axisx, axisy) {
+				var points = datapoints.points,
+					ps = datapoints.pointsize,
+					bottom = Math.min(Math.max(0, axisy.min), axisy.max),
+					i = 0, top, areaOpen = false,
+					ypos = 1, segmentStart = 0, segmentEnd = 0;
+
+				// we process each segment in two turns, first forward
+				// direction to sketch out top, then once we hit the
+				// end we go backwards to sketch the bottom
+				while (true) {
+					if (ps > 0 && i > points.length + ps)
+						break;
+
+					i += ps; // ps is negative if going backwards
+
+					var x1 = points[i - ps],
+						y1 = points[i - ps + ypos],
+						x2 = points[i], y2 = points[i + ypos];
+
+					if (areaOpen) {
+						if (ps > 0 && x1 != null && x2 == null) {
+							// at turning point
+							segmentEnd = i;
+							ps = -ps;
+							ypos = 2;
+							continue;
+						}
+
+						if (ps < 0 && i == segmentStart + ps) {
+							// done with the reverse sweep
+							ctx.fill();
+							areaOpen = false;
+							ps = -ps;
+							ypos = 1;
+							i = segmentStart = segmentEnd + ps;
+							continue;
+						}
+					}
+
+					if (x1 == null || x2 == null)
+						continue;
+
+					// clip x values
+
+					// clip with xmin
+					if (x1 <= x2 && x1 < axisx.min) {
+						if (x2 < axisx.min)
+							continue;
+						y1 = (axisx.min - x1) / (x2 - x1) * (y2 - y1) + y1;
+						x1 = axisx.min;
+					}
+					else if (x2 <= x1 && x2 < axisx.min) {
+						if (x1 < axisx.min)
+							continue;
+						y2 = (axisx.min - x1) / (x2 - x1) * (y2 - y1) + y1;
+						x2 = axisx.min;
+					}
+
+					// clip with xmax
+					if (x1 >= x2 && x1 > axisx.max) {
+						if (x2 > axisx.max)
+							continue;
+						y1 = (axisx.max - x1) / (x2 - x1) * (y2 - y1) + y1;
+						x1 = axisx.max;
+					}
+					else if (x2 >= x1 && x2 > axisx.max) {
+						if (x1 > axisx.max)
+							continue;
+						y2 = (axisx.max - x1) / (x2 - x1) * (y2 - y1) + y1;
+						x2 = axisx.max;
+					}
+
+					if (!areaOpen) {
+						// open area
+						ctx.beginPath();
+						ctx.moveTo(axisx.p2c(x1), axisy.p2c(bottom));
+						areaOpen = true;
+					}
+
+					// now first check the case where both is outside
+					if (y1 >= axisy.max && y2 >= axisy.max) {
+						ctx.lineTo(axisx.p2c(x1), axisy.p2c(axisy.max));
+						ctx.lineTo(axisx.p2c(x2), axisy.p2c(axisy.max));
+						continue;
+					}
+					else if (y1 <= axisy.min && y2 <= axisy.min) {
+						ctx.lineTo(axisx.p2c(x1), axisy.p2c(axisy.min));
+						ctx.lineTo(axisx.p2c(x2), axisy.p2c(axisy.min));
+						continue;
+					}
+
+					// else it's a bit more complicated, there might
+					// be a flat maxed out rectangle first, then a
+					// triangular cutout or reverse; to find these
+					// keep track of the current x values
+					var x1old = x1, x2old = x2;
+
+					// clip the y values, without shortcutting, we
+					// go through all cases in turn
+
+					// clip with ymin
+					if (y1 <= y2 && y1 < axisy.min && y2 >= axisy.min) {
+						x1 = (axisy.min - y1) / (y2 - y1) * (x2 - x1) + x1;
+						y1 = axisy.min;
+					}
+					else if (y2 <= y1 && y2 < axisy.min && y1 >= axisy.min) {
+						x2 = (axisy.min - y1) / (y2 - y1) * (x2 - x1) + x1;
+						y2 = axisy.min;
+					}
+
+					// clip with ymax
+					if (y1 >= y2 && y1 > axisy.max && y2 <= axisy.max) {
+						x1 = (axisy.max - y1) / (y2 - y1) * (x2 - x1) + x1;
+						y1 = axisy.max;
+					}
+					else if (y2 >= y1 && y2 > axisy.max && y1 <= axisy.max) {
+						x2 = (axisy.max - y1) / (y2 - y1) * (x2 - x1) + x1;
+						y2 = axisy.max;
+					}
+
+					// if the x value was changed we got a rectangle
+					// to fill
+					if (x1 != x1old) {
+						ctx.lineTo(axisx.p2c(x1old), axisy.p2c(y1));
+						// it goes to (x1, y1), but we fill that below
+					}
+
+					// fill triangular section, this sometimes result
+					// in redundant points if (x1, y1) hasn't changed
+					// from previous line to, but we just ignore that
+					ctx.lineTo(axisx.p2c(x1), axisy.p2c(y1));
+					ctx.lineTo(axisx.p2c(x2), axisy.p2c(y2));
+
+					// fill the other rectangle if it's there
+					if (x2 != x2old) {
+						ctx.lineTo(axisx.p2c(x2), axisy.p2c(y2));
+						ctx.lineTo(axisx.p2c(x2old), axisy.p2c(y2));
+					}
+				}
+			}
+
+			ctx.save();
+			ctx.translate(plotOffset.left, plotOffset.top);
+			ctx.lineJoin = "round";
+
+			var lw = series.lines.lineWidth,
+				sw = series.shadowSize;
+			// FIXME: consider another form of shadow when filling is turned on
+			if (lw > 0 && sw > 0) {
+				// draw shadow as a thick and thin line with transparency
+				ctx.lineWidth = sw;
+				ctx.strokeStyle = "rgba(0,0,0,0.1)";
+				// position shadow at angle from the mid of line
+				var angle = Math.PI/18;
+				plotLine(series.datapoints, Math.sin(angle) * (lw/2 + sw/2), Math.cos(angle) * (lw/2 + sw/2), series.xaxis, series.yaxis);
+				ctx.lineWidth = sw/2;
+				plotLine(series.datapoints, Math.sin(angle) * (lw/2 + sw/4), Math.cos(angle) * (lw/2 + sw/4), series.xaxis, series.yaxis);
+			}
+
+			ctx.lineWidth = lw;
+			ctx.strokeStyle = series.color;
+			var fillStyle = getFillStyle(series.lines, series.color, 0, plotHeight);
+			if (fillStyle) {
+				ctx.fillStyle = fillStyle;
+				plotLineArea(series.datapoints, series.xaxis, series.yaxis);
+			}
+
+			if (lw > 0)
+				plotLine(series.datapoints, 0, 0, series.xaxis, series.yaxis);
+			ctx.restore();
+		}
+
+		function drawSeriesPoints(series) {
+			function plotPoints(datapoints, radius, fillStyle, offset, shadow, axisx, axisy, symbol) {
+				var points = datapoints.points, ps = datapoints.pointsize;
+
+				for (var i = 0; i < points.length; i += ps) {
+					var x = points[i], y = points[i + 1];
+					if (x == null || x < axisx.min || x > axisx.max || y < axisy.min || y > axisy.max)
+						continue;
+
+					ctx.beginPath();
+					x = axisx.p2c(x);
+					y = axisy.p2c(y) + offset;
+					if (symbol == "circle")
+						ctx.arc(x, y, radius, 0, shadow ? Math.PI : Math.PI * 2, false);
+					else
+						symbol(ctx, x, y, radius, shadow);
+					ctx.closePath();
+
+					if (fillStyle) {
+						ctx.fillStyle = fillStyle;
+						ctx.fill();
+					}
+					ctx.stroke();
+				}
+			}
+
+			ctx.save();
+			ctx.translate(plotOffset.left, plotOffset.top);
+
+			var lw = series.points.lineWidth,
+				sw = series.shadowSize,
+				radius = series.points.radius,
+				symbol = series.points.symbol;
+
+			// If the user sets the line width to 0, we change it to a very
+			// small value. A line width of 0 seems to force the default of 1.
+			// Doing the conditional here allows the shadow setting to still be
+			// optional even with a lineWidth of 0.
+
+			if( lw == 0 )
+				lw = 0.0001;
+
+			if (lw > 0 && sw > 0) {
+				// draw shadow in two steps
+				var w = sw / 2;
+				ctx.lineWidth = w;
+				ctx.strokeStyle = "rgba(0,0,0,0.1)";
+				plotPoints(series.datapoints, radius, null, w + w/2, true,
+						   series.xaxis, series.yaxis, symbol);
+
+				ctx.strokeStyle = "rgba(0,0,0,0.2)";
+				plotPoints(series.datapoints, radius, null, w/2, true,
+						   series.xaxis, series.yaxis, symbol);
+			}
+
+			ctx.lineWidth = lw;
+			ctx.strokeStyle = series.color;
+			plotPoints(series.datapoints, radius,
+					   getFillStyle(series.points, series.color), 0, false,
+					   series.xaxis, series.yaxis, symbol);
+			ctx.restore();
+		}
+
+		function drawBar(x, y, b, barLeft, barRight, fillStyleCallback, axisx, axisy, c, horizontal, lineWidth) {
+			var left, right, bottom, top,
+				drawLeft, drawRight, drawTop, drawBottom,
+				tmp;
+
+			// in horizontal mode, we start the bar from the left
+			// instead of from the bottom so it appears to be
+			// horizontal rather than vertical
+			if (horizontal) {
+				drawBottom = drawRight = drawTop = true;
+				drawLeft = false;
+				left = b;
+				right = x;
+				top = y + barLeft;
+				bottom = y + barRight;
+
+				// account for negative bars
+				if (right < left) {
+					tmp = right;
+					right = left;
+					left = tmp;
+					drawLeft = true;
+					drawRight = false;
+				}
+			}
+			else {
+				drawLeft = drawRight = drawTop = true;
+				drawBottom = false;
+				left = x + barLeft;
+				right = x + barRight;
+				bottom = b;
+				top = y;
+
+				// account for negative bars
+				if (top < bottom) {
+					tmp = top;
+					top = bottom;
+					bottom = tmp;
+					drawBottom = true;
+					drawTop = false;
+				}
+			}
+
+			// clip
+			if (right < axisx.min || left > axisx.max ||
+				top < axisy.min || bottom > axisy.max)
+				return;
+
+			if (left < axisx.min) {
+				left = axisx.min;
+				drawLeft = false;
+			}
+
+			if (right > axisx.max) {
+				right = axisx.max;
+				drawRight = false;
+			}
+
+			if (bottom < axisy.min) {
+				bottom = axisy.min;
+				drawBottom = false;
+			}
+
+			if (top > axisy.max) {
+				top = axisy.max;
+				drawTop = false;
+			}
+
+			left = axisx.p2c(left);
+			bottom = axisy.p2c(bottom);
+			right = axisx.p2c(right);
+			top = axisy.p2c(top);
+
+			// fill the bar
+			if (fillStyleCallback) {
+				c.fillStyle = fillStyleCallback(bottom, top);
+				c.fillRect(left, top, right - left, bottom - top)
+			}
+
+			// draw outline
+			if (lineWidth > 0 && (drawLeft || drawRight || drawTop || drawBottom)) {
+				c.beginPath();
+
+				// FIXME: inline moveTo is buggy with excanvas
+				c.moveTo(left, bottom);
+				if (drawLeft)
+					c.lineTo(left, top);
+				else
+					c.moveTo(left, top);
+				if (drawTop)
+					c.lineTo(right, top);
+				else
+					c.moveTo(right, top);
+				if (drawRight)
+					c.lineTo(right, bottom);
+				else
+					c.moveTo(right, bottom);
+				if (drawBottom)
+					c.lineTo(left, bottom);
+				else
+					c.moveTo(left, bottom);
+				c.stroke();
+			}
+		}
+
+		function drawSeriesBars(series) {
+			function plotBars(datapoints, barLeft, barRight, fillStyleCallback, axisx, axisy) {
+				var points = datapoints.points, ps = datapoints.pointsize;
+
+				for (var i = 0; i < points.length; i += ps) {
+					if (points[i] == null)
+						continue;
+					drawBar(points[i], points[i + 1], points[i + 2], barLeft, barRight, fillStyleCallback, axisx, axisy, ctx, series.bars.horizontal, series.bars.lineWidth);
+				}
+			}
+
+			ctx.save();
+			ctx.translate(plotOffset.left, plotOffset.top);
+
+			// FIXME: figure out a way to add shadows (for instance along the right edge)
+			ctx.lineWidth = series.bars.lineWidth;
+			ctx.strokeStyle = series.color;
+
+			var barLeft;
+
+			switch (series.bars.align) {
+				case "left":
+					barLeft = 0;
+					break;
+				case "right":
+					barLeft = -series.bars.barWidth;
+					break;
+				default:
+					barLeft = -series.bars.barWidth / 2;
+			}
+
+			var fillStyleCallback = series.bars.fill ? function (bottom, top) { return getFillStyle(series.bars, series.color, bottom, top); } : null;
+			plotBars(series.datapoints, barLeft, barLeft + series.bars.barWidth, fillStyleCallback, series.xaxis, series.yaxis);
+			ctx.restore();
+		}
+
+		function getFillStyle(filloptions, seriesColor, bottom, top) {
+			var fill = filloptions.fill;
+			if (!fill)
+				return null;
+
+			if (filloptions.fillColor)
+				return getColorOrGradient(filloptions.fillColor, bottom, top, seriesColor);
+
+			var c = $.color.parse(seriesColor);
+			c.a = typeof fill == "number" ? fill : 0.4;
+			c.normalize();
+			return c.toString();
+		}
+
+		function insertLegend() {
+
+			if (options.legend.container != null) {
+				$(options.legend.container).html("");
+			} else {
+				placeholder.find(".legend").remove();
+			}
+
+			if (!options.legend.show) {
+				return;
+			}
+
+			var fragments = [], entries = [], rowStarted = false,
+				lf = options.legend.labelFormatter, s, label;
+
+			// Build a list of legend entries, with each having a label and a color
+
+			for (var i = 0; i < series.length; ++i) {
+				s = series[i];
+				if (s.label) {
+					label = lf ? lf(s.label, s) : s.label;
+					if (label) {
+						entries.push({
+							label: label,
+							color: s.color
+						});
+					}
+				}
+			}
+
+			// Sort the legend using either the default or a custom comparator
+
+			if (options.legend.sorted) {
+				if ($.isFunction(options.legend.sorted)) {
+					entries.sort(options.legend.sorted);
+				} else if (options.legend.sorted == "reverse") {
+					entries.reverse();
+				} else {
+					var ascending = options.legend.sorted != "descending";
+					entries.sort(function(a, b) {
+						return a.label == b.label ? 0 : (
+							(a.label < b.label) != ascending ? 1 : -1   // Logical XOR
+						);
+					});
+				}
+			}
+
+			// Generate markup for the list of entries, in their final order
+
+			for (var i = 0; i < entries.length; ++i) {
+
+				var entry = entries[i];
+
+				if (i % options.legend.noColumns == 0) {
+					if (rowStarted)
+						fragments.push('</tr>');
+					fragments.push('<tr>');
+					rowStarted = true;
+				}
+
+				fragments.push(
+					'<td class="legendColorBox"><div style="border:1px solid ' + options.legend.labelBoxBorderColor + ';padding:1px"><div style="width:4px;height:0;border:5px solid ' + entry.color + ';overflow:hidden"></div></div></td>' +
+					'<td class="legendLabel">' + entry.label + '</td>'
+				);
+			}
+
+			if (rowStarted)
+				fragments.push('</tr>');
+
+			if (fragments.length == 0)
+				return;
+
+			var table = '<table style="font-size:smaller;color:' + options.grid.color + '">' + fragments.join("") + '</table>';
+			if (options.legend.container != null)
+				$(options.legend.container).html(table);
+			else {
+				var pos = "",
+					p = options.legend.position,
+					m = options.legend.margin;
+				if (m[0] == null)
+					m = [m, m];
+				if (p.charAt(0) == "n")
+					pos += 'top:' + (m[1] + plotOffset.top) + 'px;';
+				else if (p.charAt(0) == "s")
+					pos += 'bottom:' + (m[1] + plotOffset.bottom) + 'px;';
+				if (p.charAt(1) == "e")
+					pos += 'right:' + (m[0] + plotOffset.right) + 'px;';
+				else if (p.charAt(1) == "w")
+					pos += 'left:' + (m[0] + plotOffset.left) + 'px;';
+				var legend = $('<div class="legend">' + table.replace('style="', 'style="position:absolute;' + pos +';') + '</div>').appendTo(placeholder);
+				if (options.legend.backgroundOpacity != 0.0) {
+					// put in the transparent background
+					// separately to avoid blended labels and
+					// label boxes
+					var c = options.legend.backgroundColor;
+					if (c == null) {
+						c = options.grid.backgroundColor;
+						if (c && typeof c == "string")
+							c = $.color.parse(c);
+						else
+							c = $.color.extract(legend, 'background-color');
+						c.a = 1;
+						c = c.toString();
+					}
+					var div = legend.children();
+					$('<div style="position:absolute;width:' + div.width() + 'px;height:' + div.height() + 'px;' + pos +'background-color:' + c + ';"> </div>').prependTo(legend).css('opacity', options.legend.backgroundOpacity);
+				}
+			}
+		}
+
+
+		// interactive features
+
+		var highlights = [],
+			redrawTimeout = null;
+
+		// returns the data item the mouse is over, or null if none is found
+		function findNearbyItem(mouseX, mouseY, seriesFilter) {
+			var maxDistance = options.grid.mouseActiveRadius,
+				smallestDistance = maxDistance * maxDistance + 1,
+				item = null, foundPoint = false, i, j, ps;
+
+			for (i = series.length - 1; i >= 0; --i) {
+				if (!seriesFilter(series[i]))
+					continue;
+
+				var s = series[i],
+					axisx = s.xaxis,
+					axisy = s.yaxis,
+					points = s.datapoints.points,
+					mx = axisx.c2p(mouseX), // precompute some stuff to make the loop faster
+					my = axisy.c2p(mouseY),
+					maxx = maxDistance / axisx.scale,
+					maxy = maxDistance / axisy.scale;
+
+				ps = s.datapoints.pointsize;
+				// with inverse transforms, we can't use the maxx/maxy
+				// optimization, sadly
+				if (axisx.options.inverseTransform)
+					maxx = Number.MAX_VALUE;
+				if (axisy.options.inverseTransform)
+					maxy = Number.MAX_VALUE;
+
+				if (s.lines.show || s.points.show) {
+					for (j = 0; j < points.length; j += ps) {
+						var x = points[j], y = points[j + 1];
+						if (x == null)
+							continue;
+
+						// For points and lines, the cursor must be within a
+						// certain distance to the data point
+						if (x - mx > maxx || x - mx < -maxx ||
+							y - my > maxy || y - my < -maxy)
+							continue;
+
+						// We have to calculate distances in pixels, not in
+						// data units, because the scales of the axes may be different
+						var dx = Math.abs(axisx.p2c(x) - mouseX),
+							dy = Math.abs(axisy.p2c(y) - mouseY),
+							dist = dx * dx + dy * dy; // we save the sqrt
+
+						// use <= to ensure last point takes precedence
+						// (last generally means on top of)
+						if (dist < smallestDistance) {
+							smallestDistance = dist;
+							item = [i, j / ps];
+						}
+					}
+				}
+
+				if (s.bars.show && !item) { // no other point can be nearby
+
+					var barLeft, barRight;
+
+					switch (s.bars.align) {
+						case "left":
+							barLeft = 0;
+							break;
+						case "right":
+							barLeft = -s.bars.barWidth;
+							break;
+						default:
+							barLeft = -s.bars.barWidth / 2;
+					}
+
+					barRight = barLeft + s.bars.barWidth;
+
+					for (j = 0; j < points.length; j += ps) {
+						var x = points[j], y = points[j + 1], b = points[j + 2];
+						if (x == null)
+							continue;
+
+						// for a bar graph, the cursor must be inside the bar
+						if (series[i].bars.horizontal ?
+							(mx <= Math.max(b, x) && mx >= Math.min(b, x) &&
+							 my >= y + barLeft && my <= y + barRight) :
+							(mx >= x + barLeft && mx <= x + barRight &&
+							 my >= Math.min(b, y) && my <= Math.max(b, y)))
+								item = [i, j / ps];
+					}
+				}
+			}
+
+			if (item) {
+				i = item[0];
+				j = item[1];
+				ps = series[i].datapoints.pointsize;
+
+				return { datapoint: series[i].datapoints.points.slice(j * ps, (j + 1) * ps),
+						 dataIndex: j,
+						 series: series[i],
+						 seriesIndex: i };
+			}
+
+			return null;
+		}
+
+		function onMouseMove(e) {
+			if (options.grid.hoverable)
+				triggerClickHoverEvent("plothover", e,
+									   function (s) { return s["hoverable"] != false; });
+		}
+
+		function onMouseLeave(e) {
+			if (options.grid.hoverable)
+				triggerClickHoverEvent("plothover", e,
+									   function (s) { return false; });
+		}
+
+		function onClick(e) {
+			triggerClickHoverEvent("plotclick", e,
+								   function (s) { return s["clickable"] != false; });
+		}
+
+		// trigger click or hover event (they send the same parameters
+		// so we share their code)
+		function triggerClickHoverEvent(eventname, event, seriesFilter) {
+			var offset = eventHolder.offset(),
+				canvasX = event.pageX - offset.left - plotOffset.left,
+				canvasY = event.pageY - offset.top - plotOffset.top,
+			pos = canvasToAxisCoords({ left: canvasX, top: canvasY });
+
+			pos.pageX = event.pageX;
+			pos.pageY = event.pageY;
+
+			var item = findNearbyItem(canvasX, canvasY, seriesFilter);
+
+			if (item) {
+				// fill in mouse pos for any listeners out there
+				item.pageX = parseInt(item.series.xaxis.p2c(item.datapoint[0]) + offset.left + plotOffset.left, 10);
+				item.pageY = parseInt(item.series.yaxis.p2c(item.datapoint[1]) + offset.top + plotOffset.top, 10);
+			}
+
+			if (options.grid.autoHighlight) {
+				// clear auto-highlights
+				for (var i = 0; i < highlights.length; ++i) {
+					var h = highlights[i];
+					if (h.auto == eventname &&
+						!(item && h.series == item.series &&
+						  h.point[0] == item.datapoint[0] &&
+						  h.point[1] == item.datapoint[1]))
+						unhighlight(h.series, h.point);
+				}
+
+				if (item)
+					highlight(item.series, item.datapoint, eventname);
+			}
+
+			placeholder.trigger(eventname, [ pos, item ]);
+		}
+
+		function triggerRedrawOverlay() {
+			var t = options.interaction.redrawOverlayInterval;
+			if (t == -1) {      // skip event queue
+				drawOverlay();
+				return;
+			}
+
+			if (!redrawTimeout)
+				redrawTimeout = setTimeout(drawOverlay, t);
+		}
+
+		function drawOverlay() {
+			redrawTimeout = null;
+
+			// draw highlights
+			octx.save();
+			overlay.clear();
+			octx.translate(plotOffset.left, plotOffset.top);
+
+			var i, hi;
+			for (i = 0; i < highlights.length; ++i) {
+				hi = highlights[i];
+
+				if (hi.series.bars.show)
+					drawBarHighlight(hi.series, hi.point);
+				else
+					drawPointHighlight(hi.series, hi.point);
+			}
+			octx.restore();
+
+			executeHooks(hooks.drawOverlay, [octx]);
+		}
+
+		function highlight(s, point, auto) {
+			if (typeof s == "number")
+				s = series[s];
+
+			if (typeof point == "number") {
+				var ps = s.datapoints.pointsize;
+				point = s.datapoints.points.slice(ps * point, ps * (point + 1));
+			}
+
+			var i = indexOfHighlight(s, point);
+			if (i == -1) {
+				highlights.push({ series: s, point: point, auto: auto });
+
+				triggerRedrawOverlay();
+			}
+			else if (!auto)
+				highlights[i].auto = false;
+		}
+
+		function unhighlight(s, point) {
+			if (s == null && point == null) {
+				highlights = [];
+				triggerRedrawOverlay();
+				return;
+			}
+
+			if (typeof s == "number")
+				s = series[s];
+
+			if (typeof point == "number") {
+				var ps = s.datapoints.pointsize;
+				point = s.datapoints.points.slice(ps * point, ps * (point + 1));
+			}
+
+			var i = indexOfHighlight(s, point);
+			if (i != -1) {
+				highlights.splice(i, 1);
+
+				triggerRedrawOverlay();
+			}
+		}
+
+		function indexOfHighlight(s, p) {
+			for (var i = 0; i < highlights.length; ++i) {
+				var h = highlights[i];
+				if (h.series == s && h.point[0] == p[0]
+					&& h.point[1] == p[1])
+					return i;
+			}
+			return -1;
+		}
+
+		function drawPointHighlight(series, point) {
+			var x = point[0], y = point[1],
+				axisx = series.xaxis, axisy = series.yaxis,
+				highlightColor = (typeof series.highlightColor === "string") ? series.highlightColor : $.color.parse(series.color).scale('a', 0.5).toString();
+
+			if (x < axisx.min || x > axisx.max || y < axisy.min || y > axisy.max)
+				return;
+
+			var pointRadius = series.points.radius + series.points.lineWidth / 2;
+			octx.lineWidth = pointRadius;
+			octx.strokeStyle = highlightColor;
+			var radius = 1.5 * pointRadius;
+			x = axisx.p2c(x);
+			y = axisy.p2c(y);
+
+			octx.beginPath();
+			if (series.points.symbol == "circle")
+				octx.arc(x, y, radius, 0, 2 * Math.PI, false);
+			else
+				series.points.symbol(octx, x, y, radius, false);
+			octx.closePath();
+			octx.stroke();
+		}
+
+		function drawBarHighlight(series, point) {
+			var highlightColor = (typeof series.highlightColor === "string") ? series.highlightColor : $.color.parse(series.color).scale('a', 0.5).toString(),
+				fillStyle = highlightColor,
+				barLeft;
+
+			switch (series.bars.align) {
+				case "left":
+					barLeft = 0;
+					break;
+				case "right":
+					barLeft = -series.bars.barWidth;
+					break;
+				default:
+					barLeft = -series.bars.barWidth / 2;
+			}
+
+			octx.lineWidth = series.bars.lineWidth;
+			octx.strokeStyle = highlightColor;
+
+			drawBar(point[0], point[1], point[2] || 0, barLeft, barLeft + series.bars.barWidth,
+					function () { return fillStyle; }, series.xaxis, series.yaxis, octx, series.bars.horizontal, series.bars.lineWidth);
+		}
+
+		function getColorOrGradient(spec, bottom, top, defaultColor) {
+			if (typeof spec == "string")
+				return spec;
+			else {
+				// assume this is a gradient spec; IE currently only
+				// supports a simple vertical gradient properly, so that's
+				// what we support too
+				var gradient = ctx.createLinearGradient(0, top, 0, bottom);
+
+				for (var i = 0, l = spec.colors.length; i < l; ++i) {
+					var c = spec.colors[i];
+					if (typeof c != "string") {
+						var co = $.color.parse(defaultColor);
+						if (c.brightness != null)
+							co = co.scale('rgb', c.brightness);
+						if (c.opacity != null)
+							co.a *= c.opacity;
+						c = co.toString();
+					}
+					gradient.addColorStop(i / (l - 1), c);
+				}
+
+				return gradient;
+			}
+		}
+	}
+
+	// Add the plot function to the top level of the jQuery object
+
+	$.plot = function(placeholder, data, options) {
+		//var t0 = new Date();
+		var plot = new Plot($(placeholder), data, options, $.plot.plugins);
+		//(window.console ? console.log : alert)("time used (msecs): " + ((new Date()).getTime() - t0.getTime()));
+		return plot;
+	};
+
+	$.plot.version = "0.8.3";
+
+	$.plot.plugins = [];
+
+	// Also add the plot function as a chainable property
+
+	$.fn.plot = function(data, options) {
+		return this.each(function() {
+			$.plot(this, data, options);
+		});
+	};
+
+	// round to nearby lower multiple of base
+	function floorInBase(n, base) {
+		return base * Math.floor(n / base);
+	}
 
 })(jQuery);


### PR DESCRIPTION
Addresses https://github.com/flot/flot/issues/1363. Add support for drawing x- and y axes **inside** the plot area instead of outside

To configure, you can use:

	xaxis, yaxis: {
		background: 'rgba(255,0,0,0.8)',	// axis background
		font: {
			background: 'rgba(255,0,0,1)',	// axis label background
		},
		labelPosition: 'inside',			// put axis inside the plot area
		reserveSpace: false, 				// don't allocate extra label space left/right beyond the plot boundary
	},
	grid: {
		axisAboveData: true,				// draw axis/labels after drawing the series
		margin: {							// margin between canvas and grid (incl. labels)
			top: 0,							// set to 0 for full-size charts if you want labels inside
			right: 0,
			bottom: 0,
			left: 0
		},
		minBorderMargin: 0,					// don't allocate additional outside space
		labelMargin: 5,						// margin between labels and axis- becomes label background padding
	}

Tested with single x- and y axis top/bottom and left/right using canvas plugin. Multiple y axes not tested.