### PR TITLE
Don't overwrite renderTimeout

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -633,6 +633,7 @@ Licensed under the MIT license.
             drawOverlay: [],
             shutdown: []
         },
+        redrawTimeout = null,
         plot = this;
 
         // public functions
@@ -2822,8 +2823,7 @@ Licensed under the MIT license.
 
         // interactive features
 
-        var highlights = [],
-            redrawTimeout = null;
+        var highlights = [];
 
         // returns the data item the mouse is over, or null if none is found
         function findNearbyItem(mouseX, mouseY, seriesFilter) {


### PR DESCRIPTION
renderTimeout may already have been set in triggerRedrawOverlay.
Defining the variable at the top of Plot fixes this bug.

The bug that I was seeing had to do with .shutdown not running
clearTimeout because renderTimeout was null.