### PR TITLE
Added support for anchored axes

### DIFF
--- a/examples/axes-anchored/index.html
+++ b/examples/axes-anchored/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<title>Flot Examples: Anchored Axes</title>
+	<link href="../examples.css" rel="stylesheet" type="text/css">
+	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="../../excanvas.min.js"></script><![endif]-->
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../src/jquery.flot.js"></script>
+	<script language="javascript" type="text/javascript" src="../../src/plugins/jquery.flot.time.js"></script>
+	<script type="text/javascript">
+
+	$(function() {
+		var oilprices = [[1167692400000,61.05777], [1167778800000,58.32], [1167865200000,57.35], [1167951600000,56.31], [1168210800000,55.55], [1168297200000,55.64], [1168383600000,54.02], [1168470000000,51.88], [1168556400000,52.99], [1168815600000,52.99], [1168902000000,51.21], [1168988400000,52.24], [1169074800000,50.48], [1169161200000,51.99], [1169420400000,51.13], [1169506800000,55.04], [1169593200000,55.37], [1169679600000,54.23], [1169766000000,55.42], [1170025200000,54.01], [1170111600000,56.97], [1170198000000,58.14], [1170284400000,58.14], [1170370800000,59.02], [1170630000000,58.74]];
+		var exchangerates = [[1167606000000,0.7580], [1167692400000,0.7580], [1167778800000,0.75470], [1167865200000,0.75490], [1167951600000,0.76130], [1168038000000,0.76550], [1168124400000,0.76930], [1168210800000,0.76940], [1168297200000,0.76880], [1168383600000,0.76780], [1168470000000,0.77080], [1168556400000,0.77270], [1168642800000,0.77490], [1168729200000,0.77410], [1168815600000,0.77410], [1168902000000,0.77320], [1168988400000,0.77270], [1169074800000,0.77370], [1169161200000,0.77240], [1169247600000,0.77120], [1169334000000,0.7720], [1169420400000,0.77210], [1169506800000,0.77170], [1169593200000,0.77040], [1169679600000,0.7690], [1169766000000,0.77110], [1169852400000,0.7740], [1169938800000,0.77450], [1170025200000,0.77450], [1170111600000,0.7740], [1170198000000,0.77160], [1170284400000,0.77130], [1170370800000,0.76780], [1170457200000,0.76880]];
+			$.plot("#placeholder", [
+				{ data: oilprices, label: "Price" },
+				{ data: exchangerates, label: "Rate", yaxis: 2 }
+			], {
+				grid: {anchorAxes: true},
+				xaxes: [ { mode: "time" } ],
+				yaxes: [ { anchorStart: 0, anchorEnd: 45 }, { anchorStart: 55, anchorEnd: 100 } ]
+			});
+	});
+
+	</script>
+</head>
+<body>
+	<div id="header">
+		<h2>Anchored axes</h2>
+	</div>
+
+	<div id="content">	
+		<div class="demo-container">
+			<div id="placeholder" class="demo-placeholder"></div>
+		</div>
+
+		<p>Multiple axes can be anchored to the grid edge. You can e.g. create a chart with multiple Y axes where one axis is above each other. Series line (or area) will never cross the other one. The start/end positions of axis can be specified in % as options.</p>
+	</div>
+</body>
+</html>

--- a/src/jquery.flot.js
+++ b/src/jquery.flot.js
@@ -699,7 +699,13 @@ Licensed under the MIT license.
                     reserveSpace: null,
 
                     // axis number or null for no sync
-                    alignTicksWithAxis: null
+                    alignTicksWithAxis: null,
+
+                    // start axis position in % when multiple axes anchored on grid edge
+                    anchorStart: null,
+
+                    // end axis position in % when multiple axes anchored on grid edge
+                    anchorEnd: null
                 },
                 yaxis: {
 
@@ -785,6 +791,9 @@ Licensed under the MIT license.
                     // value in pixels
                     axisMargin: 8,
 
+                    // multiple axes anchored on grid edge
+                    anchorAxes: false,
+
                     // value in pixels
                     borderWidth: 2,
 
@@ -826,7 +835,19 @@ Licensed under the MIT license.
             octx = null,
             xaxes = [],
             yaxes = [],
+            axesLabelsMaxDims = {
+                left: 0,
+                right: 0,
+                top: 0,
+                bottom: 0
+            },
             plotOffset = {
+                left: 0,
+                right: 0,
+                top: 0,
+                bottom: 0
+            },
+            plotOffset0 = {
                 left: 0,
                 right: 0,
                 top: 0,
@@ -1701,7 +1722,7 @@ Licensed under the MIT license.
             // has been computed already
             function identity(x) { return x; }
 
-            var s, m, t = axis.options.transform || identity,
+            var s, m, p0, t = axis.options.transform || identity,
                 it = axis.options.inverseTransform;
 
             // precompute how much the axis is scaling a point
@@ -1715,20 +1736,34 @@ Licensed under the MIT license.
                 m = Math.max(t(axis.max), t(axis.min));
             }
 
+            // recompute scaling and define position offset if multiple axes anchored on grid edge
+            if (options.grid.anchorAxes && axis.options.anchorStart < axis.options.anchorEnd) {
+                if (axis.direction === "x") {
+                    p0 = axis.options.anchorStart / 100 * plotWidth;
+                }
+                else {
+                    p0 = axis.options.anchorStart / 100 * plotHeight;
+                }
+                s = s * (axis.options.anchorEnd - axis.options.anchorStart) / 100;
+            }
+            else {
+                p0 = 0;
+            }
+
             // data point to canvas coordinate
             if (t === identity) {
 
                 // slight optimization
-                axis.p2c = function(p) { return (p - m) * s; };
+                axis.p2c = function (p) { return (p - m) * s + p0; };
             } else {
-                axis.p2c = function(p) { return (t(p) - m) * s; };
+                axis.p2c = function (p) { return (t(p) - m) * s + p0; };
             }
 
             // canvas coordinate to data point
             if (!it) {
-                axis.c2p = function(c) { return m + c / s; };
+                axis.c2p = function (c) { return m + (c - p0) / s; };
             } else {
-                axis.c2p = function(c) { return it(m + c / s); };
+                axis.c2p = function (c) { return it(m + (c - p0) / s); };
             }
         }
 
@@ -1765,6 +1800,22 @@ Licensed under the MIT license.
             // Label width/height properties are deprecated; remove in 1.0!
             axis.labelWidth = axis.tickWidth;
             axis.labelHeight = axis.tickHeight;
+
+            // save maximum label width/height for all axis positions
+            if (options.grid.anchorAxes) {
+                if (axis.options.position === "left") {
+                    axesLabelsMaxDims.left = Math.max(axesLabelsMaxDims.left, axis.labelWidth);
+                }
+                if (axis.options.position === "right") {
+                    axesLabelsMaxDims.right = Math.max(axesLabelsMaxDims.right, axis.labelWidth);
+                }
+                if (axis.options.position === "top") {
+                    axesLabelsMaxDims.top = Math.max(axesLabelsMaxDims.top, axis.labelHeight);
+                }
+                if (axis.options.position === "bottom") {
+                    axesLabelsMaxDims.bottom = Math.max(axesLabelsMaxDims.bottom, axis.labelHeight);
+                }
+            }
         }
 
         /**
@@ -1790,22 +1841,25 @@ Licensed under the MIT license.
                 found = false;
 
             // Determine the axis's position in its direction and on its side
-            $.each(isXAxis ? xaxes : yaxes, function(i, a) {
-                if (a && (a.show || a.reserveSpace)) {
-                    if (a === axis) {
-                        found = true;
-                    } else if (a.options.position === axisPosition) {
-                        if (found) {
-                            outermost = false;
-                        } else {
-                            innermost = false;
+            // (ignore if multiple axes anchored on grid edge - they all are innermost, outermost and first)
+            if (!options.grid.anchorAxes) {
+                $.each(isXAxis ? xaxes : yaxes, function(i, a) {
+                    if (a && (a.show || a.reserveSpace)) {
+                        if (a === axis) {
+                            found = true;
+                        } else if (a.options.position === axisPosition) {
+                            if (found) {
+                                outermost = false;
+                            } else {
+                                innermost = false;
+                            }
+                        }
+                        if (!found) {
+                            first = false;
                         }
                     }
-                    if (!found) {
-                        first = false;
-                    }
-                }
-            });
+                });
+            }
 
             // The outermost axis on each side has no margin
             if (outermost) {
@@ -1833,23 +1887,51 @@ Licensed under the MIT license.
             }
 
             // Compute the axis bounding box and update the plot bounds
-            if (isXAxis) {
-                contentHeight += padding;
-                if (axisPosition === "top") {
-                    axis.box = { top: plotOffset.top + axisMargin, height: contentHeight };
-                    plotOffset.top += contentHeight + axisMargin;
-                } else {
-                    plotOffset.bottom += contentHeight + axisMargin;
-                    axis.box = { top: surface.height - plotOffset.bottom, height: contentHeight };
+            if (options.grid.anchorAxes) {
+                // if multiple axes anchored on grid edge then use maximum axis label width/height
+                if (isXAxis) {
+                    if (axisPosition === "bottom") {
+                        contentHeight = axesLabelsMaxDims.bottom + padding;
+                        plotOffset.bottom = plotOffset0.bottom + contentHeight + axisMargin;
+                        axis.box = { top: surface.height - plotOffset0.bottom - contentHeight - axisMargin, height: contentHeight };
+                    }
+                    else {
+                        contentHeight = axesLabelsMaxDims.top + padding;
+                        axis.box = { top: plotOffset0.top + axisMargin, height: contentHeight };
+                        plotOffset.top = plotOffset0.top + contentHeight + axisMargin;
+                    }
+                }
+                else {
+                    if (axisPosition === "left") {
+                        contentWidth = axesLabelsMaxDims.left + padding;
+                        axis.box = { left: plotOffset0.left + axisMargin, width: contentWidth};
+                        plotOffset.left = plotOffset0.left + contentWidth + axisMargin;
+                    }
+                    else {
+                        contentWidth = axesLabelsMaxDims.right + padding;
+                        plotOffset.right = plotOffset0.right + contentWidth + axisMargin;
+                        axis.box = { left: surface.width - plotOffset0.right - contentWidth - axisMargin, width: contentWidth };
+                    }
                 }
             } else {
-                contentWidth += padding;
-                if (axisPosition === "right") {
-                    plotOffset.right += contentWidth + axisMargin;
-                    axis.box = { left: surface.width - plotOffset.right, width: contentWidth };
+                if (isXAxis) {
+                    contentHeight += padding;
+                    if (axisPosition === "top") {
+                        axis.box = { top: plotOffset.top + axisMargin, height: contentHeight };
+                        plotOffset.top += contentHeight + axisMargin;
+                    } else {
+                        plotOffset.bottom += contentHeight + axisMargin;
+                        axis.box = { top: surface.height - plotOffset.bottom, height: contentHeight };
+                    }
                 } else {
-                    axis.box = { left: plotOffset.left + axisMargin, width: contentWidth };
-                    plotOffset.left += contentWidth + axisMargin;
+                    contentWidth += padding;
+                    if (axisPosition === "right") {
+                        plotOffset.right += contentWidth + axisMargin;
+                        axis.box = { left: surface.width - plotOffset.right, width: contentWidth };
+                    } else {
+                        axis.box = { left: plotOffset.left + axisMargin, width: contentWidth };
+                        plotOffset.left += contentWidth + axisMargin;
+                    }
                 }
             }
 
@@ -2429,8 +2511,9 @@ Licensed under the MIT license.
                     if (isNaN(v) || v < axis.min || v > axis.max || (
 
                         // skip those lying on the axes if we got a border
+                        // (do not skip if multiple axes anchored on grid edge)
                         t === "full" && ((typeof bw === "object" && bw[axis.position] > 0) || bw > 0) &&
-                        (v === axis.min || v === axis.max)
+                        (v === axis.min || v === axis.max) && !options.grid.anchorAxes
                     )) {
                         continue;
                     }


### PR DESCRIPTION
Added support for anchored axes. It means that multiple axes can be anchored to the grid edge. With this you can e.g. create a chart with multiple Y axes where one axis is above each other. Series line (or area) will never cross the other one. The start/end positions of axis can be specified in % as options.

![flot-stacked-axes](https://cloud.githubusercontent.com/assets/8308820/6485895/5b2dbf14-c287-11e4-9c9f-94002ce34d40.png)

