### PR TITLE
add bower.json in parallel to old-school component.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,14 @@
+{
+	"name": "Flot",
+	"version": "0.8.3",
+	"authors": [
+		"Nick Schonning <nschonni@gmail.com>"
+	],
+	"description": "Flot is a Javascript plotting library for jQuery. Read more at the website: http://www.flotcharts.org/",
+	"main": "jquery.flot.js",
+	"license": "https://github.com/flot/flot/blob/master/LICENSE.txt",
+	"homepage": "http://www.flotcharts.org/",
+	"dependencies": {
+		"jquery": ">= 1.2.6"
+	}
+}


### PR DESCRIPTION
Issue #1054 asks that you rename `component.json` to `bower.json`. You appropriately held off until a new point release as removing `component.json` would be a breaking change for tools which are looking for it.

As 2 years has now passed and no new point release has been produced, more modern build tools are now struggling to work with Flot. As such, I am requesting you add `bower.json` in parallel to `component.json` and to release a patch version (0.8.4). This would allow newer tools to use `bower.json` as expected, while older tools which are looking for `component.json` would still find it. The only caveat is that, until you do remove `component.json`, you would need to maintain a 3rd meta file when releasing (`package.json`, `component.json`, and `bower.json`).

Thank you for considering this change. If it can happen soon enough, I can get Flot into my current project. Else, I'm sitting on Chart.js for another job... :)
