### PR TITLE
A circle line should not be there on pie chart without donut #1454

### DIFF
--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -74,7 +74,8 @@ More detail and specific examples can be found in the included HTML file.
 			centerLeft = null,
 			centerTop = null,
 			processed = false,
-			ctx = null;
+			ctx = null
+			options = plot.getOptions();
 
 		// interactive variables
 


### PR DESCRIPTION
The "options" which be used by many function should be init.