### PR TITLE
Undefined options variable fix on drawDonutHole method

### DIFF
--- a/jquery.flot.pie.js
+++ b/jquery.flot.pie.js
@@ -533,6 +533,8 @@ More detail and specific examples can be found in the included HTML file.
 		// Placed here because it needs to be accessed from multiple locations
 
 		function drawDonutHole(layer) {
+			var options = plot.getOptions();
+			
 			if (options.series.pie.innerRadius > 0) {
 
 				// subtract the center


### PR DESCRIPTION
In some cases, options is not defined in drawDonutHole function and it throws this error "Cannot read property 'series' of null".