### PR TITLE
Add .gitattributes to reduce size of final package.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/API.md export-ignore
+/CONTRIBUTING.md export-ignore
+/FAQ.md export-ignore
+/Makefile export-ignore
+/NEWS.md export-ignore
+/PLUGINS.md export-ignore
+/README.md export-ignore
+/examples export-ignore


### PR DESCRIPTION
Developer documentation and tools can easily be excluded from the bower package. This will reduce the amount of files transferred during production deployments.