### PR TITLE
Added ability to pass x-ranges and functions as parameters to plot

### DIFF
--- a/src/jquery.flot.js
+++ b/src/jquery.flot.js
@@ -1204,10 +1204,10 @@ Licensed under the MIT license.
                     $.extend(true, s, d[i]);
 
                     d[i].data = s.data;
-                } 
+                }
                 else {
                     s.data = getSeriesDataFromArgs(d[i]);
-                }   
+                }
                 res.push(s);
             }
 
@@ -1215,29 +1215,32 @@ Licensed under the MIT license.
         }
 
         function getSeriesDataFromArgs(seriesData) {
+
             // seriesData is either the raw series array, or if series is an object, 
-            // the value of the 'data' property
+            // seriesData is the value of the 'data' property
+
             if (seriesData.length === 2 && typeof seriesData[1] === "function") {
-                var xVar = seriesData[0],
-                    yfunc = seriesData[1];
-                return computeFunctionSeriesData(xVar, yfunc);
-            } else if (seriesData.length === 3 && typeof seriesData[1] === "function" && typeof seriesData[2] === "function") {
-                var tVar = seriesData[0],
-                    xfunc = seriesData[1],
-                    yfunc = seriesData[2];
-                return computeFunctionSeriesData(tVar, xfunc, yfunc);
+                return computeFunctionSeriesData(seriesData[0], seriesData[1]);
+            } else if (seriesData.length === 3 && typeof seriesData[1] === "function" &&
+                typeof seriesData[2] === "function") {
+                return computeFunctionSeriesData(seriesData[0], seriesData[1], seriesData[2]);
             } else {
                 return seriesData;
             }
         }
 
         function computeFunctionSeriesData(indVar, depFunc1, depFunc2) {
+
             // Compute [x,y(x)] or [x(t),y(t)] given independent variable 
             // and dependent variable functions
+            
             var seriesData = [],
                 indArray = [];
-            if (hasOwnProperty.call(indVar,"min") && hasOwnProperty.call(indVar,"max") && hasOwnProperty.call(indVar,"n")) {
+            if (hasOwnProperty.call(indVar,"min") && hasOwnProperty.call(indVar,"max") &&
+                hasOwnProperty.call(indVar,"n")) {
+                
                 // independent variable specified as a range
+                
                 var min     = indVar.min,
                     max     = indVar.max,
                     n       = indVar.n,
@@ -1246,19 +1249,25 @@ Licensed under the MIT license.
                     indArray.push(min + delta*j);
                 }
             } else if (indVar.length) {
+                
                 // independent variable specified as an array
+                
                 indArray = indVar;
             } else {
                 throw new Error("Invalid specification of independent variable.");
             }
             
-            for (var j = 0; j < indArray.length; j++) {
-                var indVal = indArray[j];
+            for (var k = 0; k < indArray.length; k++) {
+                var indVal = indArray[k];
                 if (depFunc2) {
+                    
                     // t, x(t), y(t)
+                    
                     seriesData.push([depFunc1(indVal), depFunc2(indVal)]);
                 } else {
+                    
                     // x, y(x)
+                    
                     seriesData.push([indVal, depFunc1(indVal)]);
                 }
             }


### PR DESCRIPTION
To plot data, currently, a raw data array must be specified for each series (e.g. [[0,0],[1,1],[2,3],..]). Thus, plotting functions requires the user to perform somewhat tedious setup work to convert a function to a list of x,y pairs. 

I've prepared a jsfiddle that illustrates how the new syntax works: [https://jsfiddle.net/shimizust/yurfnry1/](https://jsfiddle.net/shimizust/yurfnry1/)

This change makes it much simpler to plot functions by allowing the user to specify either an array or range for x and a function for y. I also added the ability to plot parametric functions, where the independent variable is t, and the x(t) and y(t) functions are specified. 

Existing syntax still works properly. Here are examples of the new syntax:

`$("#plot1").plot([ series1, series2, series3,...]);`

where each series can be defined as follows:

```
seriesN = [ {min: 0, max: 5, n: 100}, function(x) { return Math.sin(x); } ] 
// plot of y = sin(x) from 0 to 5 with 100 points

seriesN = [ [0,1,2,3,4,5], function(x) { return Math.abs(x); } ] 
// plot of y = |x| for x = 0,1,2,3,4,5

seriesN = [ {min: 0, max: 2*Math.PI, n:100}, function(t) { return Math.sin(t); }, function(t) { return Math.cos(t); } ] 
// plot of y(t) = cos(t), x(t) = sin(t), for t = 0 to 2*pi with 100 points

seriesN = [ [0,1,2,3,4,5], function(t) { return t*t; }, function(t) { return t; } ]
// plot of y(t) = t, x(t) = t^2, for t = 0,1,2,3,4,5

// all the above also work by defining inside the "data" property
```

Compare to the typical setup work required for each function (if you want different x values):

```
var d1 = [];
for (var i = 0; i < 10; i += 0.1) {
	d1.push([i, Math.sin(i)]);
}
$.plot("#plot1",[d1]);
```