### PR TITLE
Added bower.json for easier use with grunt and gulp.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+	"name": "Flot",
+	"version": "0.8.3",
+	"main": "jquery.flot.js",
+	"scripts": {
+		"test": "make test"
+	},
+	"devDependencies": {
+		"jshint": "0.9.1"
+	}
+}


### PR DESCRIPTION
When using gulp or grunt, a great way to build an app is to use the main-bower-files pattern together with for example gulp-load-plugins for gulp. This is not possible if no bower.json file is present.