### PR TITLE
examples: Fix warning produced by linter about dead code

### DIFF
--- a/examples/axes-time-zones/date.js
+++ b/examples/axes-time-zones/date.js
@@ -727,7 +727,7 @@
       return res;
     }
 
-    this.zoneFileBasePath;
+    this.zoneFileBasePath = undefined;
     this.zoneFiles = ['africa', 'antarctica', 'asia', 'australasia', 'backward', 'etcetera', 'europe', 'northamerica', 'pacificnew', 'southamerica'];
     this.loadingSchemes = {
       PRELOAD_ALL: 'preloadAll',


### PR DESCRIPTION
The coverity javascript linter produces a warning here about
dead code with no effect. This is a minor change, but would help
folks using such linting tools.