### PR TITLE
Detached DOM element

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -677,7 +677,7 @@ Licensed under the MIT license.
         plot.destroy = function () {
             shutdown();
             placeholder.removeData("plot").empty();
-
+            placeholder = null;
             series = [];
             options = null;
             surface = null;


### PR DESCRIPTION
I've released link to placeholder in destructor to avoid memory leak. Otherwise detached placeholder DOM element is hanging in memory when it doesn't actually exist.