### PR TITLE
Fixed undefined reference on the jquery.flot.pie plugin because of a …

### DIFF
--- a/src/plugins/jquery.flot.pie.js
+++ b/src/plugins/jquery.flot.pie.js
@@ -542,6 +542,7 @@ More detail and specific examples can be found in the included HTML file.
         // Placed here because it needs to be accessed from multiple locations
 
         function drawDonutHole(layer) {
+            var options = plot.getOptions();
             if (options.series.pie.innerRadius > 0) {
 
                 // subtract the center
@@ -663,7 +664,7 @@ More detail and specific examples can be found in the included HTML file.
         // trigger click or hover event (they send the same parameters so we share their code)
 
         function triggerClickHoverEvent(eventname, e) {
-
+            var options = plot.getOptions();
             var offset = plot.offset(),
                 canvasX = parseInt(e.pageX - offset.left, 10),
                 canvasY = parseInt(e.pageY - offset.top, 10),


### PR DESCRIPTION
Fixed undefined reference on the jquery.flot.pie plugin because of a missing getOptions function call. @jcblw @nschonni @dnschnur

Please allow the merge. Thanks!