### PR TITLE
Ability to overload colours for legend

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2722,7 +2722,8 @@ Licensed under the MIT license.
             }
 
             var fragments = [], entries = [], rowStarted = false,
-                lf = options.legend.labelFormatter, s, label;
+                lf = options.legend.labelFormatter, s, label,
+                colors = options.legend.colors;
 
             // Build a list of legend entries, with each having a label and a color
 
@@ -2733,7 +2734,7 @@ Licensed under the MIT license.
                     if (label) {
                         entries.push({
                             label: label,
-                            color: s.color
+                            color: colors && colors[i] ? colors[i] : s.color
                         });
                     }
                 }


### PR DESCRIPTION
I was faced with the next problem:
In order to use ```fillBelowTo``` & ```fillColor``` options I was needed to show different colors in the legend label boxes and in lines.
Unfortunately its not supported right now, I've added a small option to use the next settings for legend something like:
```
        legend: {
          colors: [
            '#000',
            '#FFF',
          ]
        }
```

Before:
![screen shot 2018-12-03 at 14 16 07](https://user-images.githubusercontent.com/15165282/49370919-c4e4e600-f706-11e8-8e2a-330fdbc07ea2.png)

After:
![screen shot 2018-12-03 at 14 20 04](https://user-images.githubusercontent.com/15165282/49370924-ca423080-f706-11e8-868a-7f723ae11333.png)
