### PR TITLE
Add pan mode options to enable/disable smart pan

### DIFF
--- a/docs/navigate.md
+++ b/docs/navigate.md
@@ -60,7 +60,7 @@ intermediate pans, the plot will then not update until the mouse button is
 released).
 
 **mode** a string specifies the pan mode for mouse interaction. Accepted values:
-empty string for normal mode: no pan hint or direction snapping;
+'manual': no pan hint or direction snapping;
 'smart': The graph shows pan hint bar and the pan movement will snap
 to one direction when the drag direction is close to it;
 'smartLock'. The graph shows pan hint bar and the pan movement will always
@@ -71,7 +71,7 @@ Default: 'smart'.
 and double tap (to recenter).
 
 **touchMode** a string specifies the pan mode of touch pan.
-The accepted values is the sams as **mode** option. Default: '' (normal)
+The accepted values is the sams as **mode** option. Default: 'manual'
 
 Example API usage:
 ```js

--- a/docs/navigate.md
+++ b/docs/navigate.md
@@ -20,7 +20,7 @@ The plugin supports these options:
         interactive: false,
         active: false,
         cursor: "move",     // CSS mouse cursor value used when dragging, e.g. "pointer"
-        frameRate: 20,
+        frameRate: 60,
         mode: "smart",       // enable smart pan mode
         enableTouch: false,
         touchMode: ""

--- a/docs/navigate.md
+++ b/docs/navigate.md
@@ -20,8 +20,10 @@ The plugin supports these options:
         interactive: false,
         active: false,
         cursor: "move",     // CSS mouse cursor value used when dragging, e.g. "pointer"
-        frameRate: 60,
-        mode: "smart"       // enable smart pan mode
+        frameRate: 20,
+        mode: "smart",       // enable smart pan mode
+        enableTouch: false,
+        touchMode: ""
     }
 
     xaxis: {
@@ -56,6 +58,20 @@ user when dragging.
 update itself while the user is panning around on it (set to null to disable
 intermediate pans, the plot will then not update until the mouse button is
 released).
+
+**mode** a string specifies the pan mode for mouse interaction. Accepted values:
+empty string for normal mode: no pan hint or direction snapping;
+'smart': The graph shows pan hint bar and the pan movement will snap
+to one direction when the drag direction is close to it;
+'smartLock'. The graph shows pan hint bar and the pan movement will always
+snap to a direction that the drag diorection started with.
+Default: 'smart'.
+
+**enableTouch** enables the touch support, including pan (to drag), pinch (to zoom and move),
+and double tap (to recenter).
+
+**touchMode** a string specifies the pan mode of touch pan.
+The accepted values is the sams as **mode** option. Default: '' (normal)
 
 Example API usage:
 ```js

--- a/source/jquery.flot.navigate.js
+++ b/source/jquery.flot.navigate.js
@@ -68,7 +68,7 @@ intermediate pans, the plot will then not update until the mouse button is
 released).
 
 **mode** a string specifies the pan mode for mouse interaction. Accepted values:
-empty string for normal mode: no pan hint or direction snapping;
+'manual': no pan hint or direction snapping;
 'smart': The graph shows pan hint bar and the pan movement will snap
 to one direction when the drag direction is close to it;
 'smartLock'. The graph shows pan hint bar and the pan movement will always
@@ -143,7 +143,8 @@ can set the default in the options.
     function initNevigation(plot, options) {
         var panAxes = null;
         var canDrag = false;
-        var smartPanLock = options.pan.mode === 'smartLock',
+        var useManualPan = options.pan.mode === 'manual',
+            smartPanLock = options.pan.mode === 'smartLock',
             useSmartPan = smartPanLock || options.pan.mode === 'smart';
 
         function onZoomClick(e, zoomOut, amount) {
@@ -273,7 +274,7 @@ can set the default in the options.
 
             if (useSmartPan) {
                 plotState = plot.navigationState(page.X, page.Y);
-            } else {
+            } else if (useManualPan) {
                 prevDragPosition.x = page.X;
                 prevDragPosition.y = page.Y;
             }
@@ -289,7 +290,7 @@ can set the default in the options.
                         x: plotState.startPageX - page.X,
                         y: plotState.startPageY - page.Y
                     }, plotState, panAxes, false, smartPanLock);
-                } else {
+                } else if (useManualPan) {
                     plot.pan({
                         left: prevDragPosition.x - page.X,
                         top: prevDragPosition.y - page.Y,
@@ -309,7 +310,7 @@ can set the default in the options.
                         x: plotState.startPageX - page.X,
                         y: plotState.startPageY - page.Y
                     }, plotState, panAxes, false, smartPanLock);
-                } else {
+                } else if (useManualPan) {
                     plot.pan({
                         left: prevDragPosition.x - page.X,
                         top: prevDragPosition.y - page.Y,
@@ -340,7 +341,7 @@ can set the default in the options.
                     y: plotState.startPageY - page.Y
                 }, plotState, panAxes, false, smartPanLock);
                 plot.smartPan.end();
-            } else {
+            } else if (useManualPan) {
                 plot.pan({
                     left: prevDragPosition.x - page.X,
                     top: prevDragPosition.y - page.Y,

--- a/source/jquery.flot.navigate.js
+++ b/source/jquery.flot.navigate.js
@@ -67,6 +67,13 @@ update itself while the user is panning around on it (set to null to disable
 intermediate pans, the plot will then not update until the mouse button is
 released).
 
+**mode** a string specifies the pan mode for mouse interaction. Accepted values:
+empty string for normal mode: no pan hint or direction snapping;
+'smart': The graph shows pan hint bar and the pan movement will snap
+to one direction when the drag direction is close to it;
+'smartLock'. The graph shows pan hint bar and the pan movement will always
+snap to a direction that the drag diorection started with.
+
 Example API usage:
 ```js
     plot = $.plot(...);
@@ -107,7 +114,8 @@ can set the default in the options.
             interactive: false,
             active: false,
             cursor: "move",
-            frameRate: 60
+            frameRate: 60,
+            mode: 'smart'
         },
         xaxis: {
             axisZoom: true, //zoom axis when mouse over it is allowed
@@ -129,8 +137,14 @@ can set the default in the options.
     var PANHINT_LENGTH_CONSTANT = $.plot.uiConstants.PANHINT_LENGTH_CONSTANT;
 
     function init(plot) {
+        plot.hooks.processOptions.push(initNevigation);
+    }
+
+    function initNevigation(plot, options) {
         var panAxes = null;
         var canDrag = false;
+        var smartPanLock = options.pan.mode === 'smartLock',
+            useSmartPan = smartPanLock || options.pan.mode === 'smart';
 
         function onZoomClick(e, zoomOut, amount) {
             var page = browser.getPageXY(e);
@@ -174,6 +188,7 @@ can set the default in the options.
             panHint = null,
             panTimeout = null,
             plotState,
+            prevDragPosition = { x: 0, y: 0 },
             isPanAction = false;
 
         function onMouseWheel(e, delta) {
@@ -255,29 +270,54 @@ can set the default in the options.
             }
 
             plot.getPlaceholder().css('cursor', plot.getOptions().pan.cursor);
-            plotState = plot.navigationState(page.X, page.Y);
-        }
 
+            if (useSmartPan) {
+                plotState = plot.navigationState(page.X, page.Y);
+            } else {
+                prevDragPosition.x = page.X;
+                prevDragPosition.y = page.Y;
+            }
+        }
+        
         function onDrag(e) {
             var page = browser.getPageXY(e);
             var frameRate = plot.getOptions().pan.frameRate;
 
             if (frameRate === -1) {
-                plot.smartPan({
-                    x: plotState.startPageX - page.X,
-                    y: plotState.startPageY - page.Y
-                }, plotState, panAxes);
-
+                if (useSmartPan) {
+                    plot.smartPan({
+                        x: plotState.startPageX - page.X,
+                        y: plotState.startPageY - page.Y
+                    }, plotState, panAxes, false, smartPanLock);
+                } else {
+                    plot.pan({
+                        left: prevDragPosition.x - page.X,
+                        top: prevDragPosition.y - page.Y,
+                        axes: panAxes
+                    });
+                    prevDragPosition.x = page.X;
+                    prevDragPosition.y = page.Y;
+                }
                 return;
             }
 
             if (panTimeout || !frameRate) return;
 
             panTimeout = setTimeout(function() {
-                plot.smartPan({
-                    x: plotState.startPageX - page.X,
-                    y: plotState.startPageY - page.Y
-                }, plotState, panAxes);
+                if (useSmartPan) {
+                    plot.smartPan({
+                        x: plotState.startPageX - page.X,
+                        y: plotState.startPageY - page.Y
+                    }, plotState, panAxes, false, smartPanLock);
+                } else {
+                    plot.pan({
+                        left: prevDragPosition.x - page.X,
+                        top: prevDragPosition.y - page.Y,
+                        axes: panAxes
+                    });
+                    prevDragPosition.x = page.X;
+                    prevDragPosition.y = page.Y;
+                }
 
                 panTimeout = null;
             }, 1 / frameRate * 1000);
@@ -293,11 +333,22 @@ can set the default in the options.
             var page = browser.getPageXY(e);
 
             plot.getPlaceholder().css('cursor', prevCursor);
-            plot.smartPan({
-                x: plotState.startPageX - page.X,
-                y: plotState.startPageY - page.Y
-            }, plotState, panAxes);
-            panHint = null;
+
+            if (useSmartPan) {
+                plot.smartPan({
+                    x: plotState.startPageX - page.X,
+                    y: plotState.startPageY - page.Y
+                }, plotState, panAxes, false, smartPanLock);
+                plot.smartPan.end();
+            } else {
+                plot.pan({
+                    left: prevDragPosition.x - page.X,
+                    top: prevDragPosition.y - page.Y,
+                    axes: panAxes
+                });
+                prevDragPosition.x = 0;
+                prevDragPosition.y = 0;
+            }
         }
 
         function onDblClick(e) {
@@ -513,6 +564,22 @@ can set the default in the options.
             return delta;
         }
 
+        var lockedDirection = null;
+        var lockDeltaDirection = function(delta) {
+            if (!lockedDirection && Math.max(Math.abs(delta.x), Math.abs(delta.y)) >= SNAPPING_CONSTANT) {
+                lockedDirection = Math.abs(delta.x) < Math.abs(delta.y) ? 'y' : 'x';
+            }
+
+            switch (lockedDirection) {
+                case 'x':
+                    return { x: delta.x, y: 0 };
+                case 'y':
+                    return { x: 0, y: delta.y };
+                default:
+                    return { x: 0, y: 0 };
+            }
+        }
+
         var isDiagonalMode = function(delta) {
             if (Math.abs(delta.x) > 0 && Math.abs(delta.y) > 0) {
                 return true;
@@ -532,11 +599,11 @@ can set the default in the options.
         }
 
         var prevDelta = { x: 0, y: 0 };
-        plot.smartPan = function(delta, initialState, panAxes, preventEvent) {
-            var snap = shouldSnap(delta),
+        plot.smartPan = function(delta, initialState, panAxes, preventEvent, smartLock) {
+            var snap = smartLock ? true : shouldSnap(delta),
                 axes = plot.getAxes(),
                 opts;
-            delta = adjustDeltaToSnap(delta);
+            delta = smartLock ? lockDeltaDirection(delta) : adjustDeltaToSnap(delta);
 
             if (isDiagonalMode(delta)) {
                 initialState.diagMode = true;
@@ -615,6 +682,13 @@ can set the default in the options.
                 plot.getPlaceholder().trigger("plotpan", [plot, delta, panAxes, initialState]);
             }
         };
+
+        plot.smartPan.end = function() {
+            panHint = null;
+            lockedDirection = null;
+            prevDelta = { x: 0, y: 0 };
+            plot.triggerRedrawOverlay();
+        }
 
         function shutdown(plot, eventHolder) {
             eventHolder.unbind("mousewheel", onMouseWheel);

--- a/source/jquery.flot.touchNavigate.js
+++ b/source/jquery.flot.touchNavigate.js
@@ -151,7 +151,7 @@
 
         doubleTap = {
             recenterPlot: function(e) {
-                if (e && e.details && e.details.type === 'touchMove') {
+                if (e && e.detail && e.detail.type === 'touchmove') {
                     // do not recenter during touch moving;
                     return;
                 }

--- a/source/jquery.flot.touchNavigate.js
+++ b/source/jquery.flot.touchNavigate.js
@@ -6,7 +6,7 @@
     var options = {
         pan: {
             enableTouch: false,
-            touchMode: ''
+            touchMode: 'manual'
         }
     };
 
@@ -31,6 +31,7 @@
                 navigationConstraint: 'unconstrained',
                 initialState: null,
             },
+            useManualPan = options.pan.touchMode === 'manual',
             smartPanLock = options.pan.touchMode === 'smartLock',
             useSmartPan = smartPanLock || options.pan.touchMode === 'smart',
             pan, pinch, doubleTap;
@@ -79,7 +80,7 @@
                         x: navigationState.initialState.startPageX - point.x,
                         y: navigationState.initialState.startPageY - point.y
                     }, navigationState.initialState, navigationState.touchedAxis, false, smartPanLock);
-                } else {
+                } else if (useManualPan) {
                     plot.pan({
                         left: -delta(e, 'pan', gestureState).x,
                         top: -delta(e, 'pan', gestureState).y,

--- a/tests/jquery.flot.navigate-interaction.Test.js
+++ b/tests/jquery.flot.navigate-interaction.Test.js
@@ -116,7 +116,7 @@ describe("flot navigate plugin interactions", function () {
 
     it('do non-smart pans on mouse drag in non-smart pan mode', function () {
         var oldPanMode = options.pan.mode;
-        options.pan.mode = '';
+        options.pan.mode = 'manual';
         var oldFrameRate = options.pan.frameRate;
         options.pan.frameRate = -1;
 
@@ -215,6 +215,50 @@ describe("flot navigate plugin interactions", function () {
         expect(xaxis.max).toBe(initialXmax);
         expect(yaxis.min).toBeGreaterThan(initialYmin);
         expect(yaxis.max).toBeGreaterThan(initialYmax);
+
+        options.pan.mode = oldPanMode;
+        options.pan.frameRate = oldFrameRate;
+    });
+
+    it('do not move graph on mouse drag if pan mode is invalid', function () {
+        var oldPanMode = options.pan.mode;
+        options.pan.mode = '';
+        var oldFrameRate = options.pan.frameRate;
+        options.pan.frameRate = -1;
+
+        plot = $.plot(placeholder, [
+            [[0, 0],
+            [10, 10]]
+        ], options);
+
+        eventHolder = plot.getEventHolder();
+        var xaxis = plot.getXAxes()[0];
+        var yaxis = plot.getYAxes()[0];
+        var initialXmin = xaxis.min,
+            initialXmax = xaxis.max,
+            initialYmin = yaxis.min,
+            initialYmax = yaxis.max;
+
+        // do not drag in all cases
+        simulate.mouseDown(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50 + plot.width() / 2, 70);
+        simulate.mouseUp(eventHolder, 50 + plot.width(), 70);
+
+        expect(xaxis.min).toBe(initialXmin);
+        expect(xaxis.max).toBe(initialXmax);
+        expect(yaxis.min).toBe(initialYmin);
+        expect(yaxis.max).toBe(initialYmax);
+        
+        simulate.mouseDown(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50, 70 + plot.height());
+        simulate.mouseUp(eventHolder, 50, 70 + plot.height());
+        
+        expect(xaxis.min).toBe(initialXmin);
+        expect(xaxis.max).toBe(initialXmax);
+        expect(yaxis.min).toBe(initialYmin);
+        expect(yaxis.max).toBe(initialYmax);
 
         options.pan.mode = oldPanMode;
         options.pan.frameRate = oldFrameRate;

--- a/tests/jquery.flot.navigate-interaction.Test.js
+++ b/tests/jquery.flot.navigate-interaction.Test.js
@@ -28,26 +28,135 @@ describe("flot navigate plugin interactions", function () {
             .find('#test-container');
     });
 
-    it('pans on mouse drag', function () {
+    it('do smart pans on mouse drag by default', function () {
         plot = $.plot(placeholder, [
             [[0, 0],
             [10, 10]]
         ], options);
 
         eventHolder = plot.getEventHolder();
-
-        simulate.mouseDown(eventHolder, 50, 70);
-        simulate.mouseMove(eventHolder, 50, 70);
-        simulate.mouseMove(eventHolder, 50 + plot.width(), 70);
-        simulate.mouseUp(eventHolder, 50 + plot.width(), 70);
-
         var xaxis = plot.getXAxes()[0];
         var yaxis = plot.getYAxes()[0];
+
+        // drag almost horizontally snap to x direction
+        simulate.mouseDown(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50 + plot.width(), 80);
+        simulate.mouseUp(eventHolder, 50 + plot.width(), 80);
 
         expect(xaxis.min).toBe(-10);
         expect(xaxis.max).toBe(0);
         expect(yaxis.min).toBe(0);
         expect(yaxis.max).toBe(10);
+
+        // drag almost vertically snap to y direction
+        simulate.mouseDown(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 60, 70 + plot.height());
+        simulate.mouseUp(eventHolder, 60, 70 + plot.height());
+
+        expect(xaxis.min).toBe(-10);
+        expect(xaxis.max).toBe(0);
+        expect(yaxis.min).toBe(10);
+        expect(yaxis.max).toBe(20);
+
+        // drag diagonally do not snap
+        simulate.mouseDown(eventHolder, plot.width() - 50, plot.height() - 70);
+        simulate.mouseMove(eventHolder, plot.width() - 50, plot.height() - 70);
+        simulate.mouseMove(eventHolder, -50, -70);
+        simulate.mouseUp(eventHolder, -50, -70);
+
+        expect(xaxis.min).toBe(0);
+        expect(xaxis.max).toBe(10);
+        expect(yaxis.min).toBe(0);
+        expect(yaxis.max).toBe(10);
+    });
+
+    it('do non-smart pans on mouse drag in non-smart pan mode', function () {
+        var oldPanMode = options.pan.mode;
+        options.pan.mode = '';
+
+        plot = $.plot(placeholder, [
+            [[0, 0],
+            [10, 10]]
+        ], options);
+
+        eventHolder = plot.getEventHolder();
+        var xaxis = plot.getXAxes()[0];
+        var yaxis = plot.getYAxes()[0];
+
+        // drag almost horizontally do not snap
+        simulate.mouseDown(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50 + plot.width(), 80);
+        simulate.mouseUp(eventHolder, 50 + plot.width(), 80);
+
+        expect(xaxis.min).toBe(-10);
+        expect(xaxis.max).toBe(0);
+        expect(yaxis.min).toBeGreaterThan(0);
+        expect(yaxis.max).toBeGreaterThan(10);
+
+        // drag almost vertically do not snap
+        simulate.mouseDown(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 60, 60 + plot.height());
+        simulate.mouseUp(eventHolder, 60, 60 + plot.height());
+
+        expect(xaxis.min).toBeLessThan(-10);
+        expect(xaxis.max).toBeLessThan(0);
+        expect(yaxis.min).toBe(10);
+        expect(yaxis.max).toBe(20);
+
+        options.pan.mode = oldPanMode;
+    });
+
+    it('lock smart pan snap direction on mouse drag in smart-lock pan mode', function () {
+        var oldPanMode = options.pan.mode;
+        options.pan.mode = 'smartLock';
+        var oldFrameRate = options.pan.frameRate;
+        options.pan.frameRate = -1;
+
+        plot = $.plot(placeholder, [
+            [[0, 0],
+            [10, 10]]
+        ], options);
+
+        eventHolder = plot.getEventHolder();
+        var xaxis = plot.getXAxes()[0];
+        var yaxis = plot.getYAxes()[0];
+        var initialXmin = xaxis.min,
+            initialXmax = xaxis.max,
+            initialYmin = yaxis.min,
+            initialYmax = yaxis.max;
+
+        // drag almost horizontally then vertically snap to x direction
+        simulate.mouseDown(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50 + plot.width() / 2, 80);
+        simulate.mouseMove(eventHolder, 50 + plot.width(), 70 + plot.height());
+        simulate.mouseUp(eventHolder, 50 + plot.width(), 70 + plot.height());
+
+        expect(xaxis.min).toBeLessThan(initialXmin);
+        expect(xaxis.max).toBeLessThan(initialXmax);
+        expect(yaxis.min).toBe(initialYmin);
+        expect(yaxis.max).toBe(initialYmax);
+
+        // drag almost vertically then horizontally snap to y direction
+        plot.recenter({});
+
+        simulate.mouseDown(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 50, 70);
+        simulate.mouseMove(eventHolder, 60, 70 + plot.height());
+        simulate.mouseMove(eventHolder, 50 + plot.width(), 70 + plot.height());
+        simulate.mouseUp(eventHolder, 50 + plot.width(), 70 + plot.height());
+
+        expect(xaxis.min).toBe(initialXmin);
+        expect(xaxis.max).toBe(initialXmax);
+        expect(yaxis.min).toBeGreaterThan(initialYmin);
+        expect(yaxis.max).toBeGreaterThan(initialYmax);
+
+        options.pan.mode = oldPanMode;
+        options.pan.frameRate = oldFrameRate;
     });
 
     it('zooms out on mouse scroll down', function () {

--- a/tests/jquery.flot.touchNavigate.Test.js
+++ b/tests/jquery.flot.touchNavigate.Test.js
@@ -605,6 +605,41 @@ describe("flot touch navigate plugin", function () {
         options.pan.touchMode = oldTouchMode;
       });
 
+      it('should not drag if pan mode is invalid', function () {
+        var oldTouchMode = options.pan.touchMode;
+        options.pan.touchMode = '';
+
+        plot = $.plot(placeholder, [
+            [
+                [-10, -10],
+                [120, 120]
+            ]
+        ], options);
+
+        var eventHolder = plot.getEventHolder(),
+            xaxis = plot.getXAxes()[0],
+            yaxis = plot.getYAxes()[0],
+            initialXmin = xaxis.min,
+            initialXmax = xaxis.max,
+            initialYmin = yaxis.min,
+            initialYmax = yaxis.max,
+            canvasCoords = [ { x : 1, y : 1 }, { x : 100, y : 100 }],
+            pointCoords = [
+                getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
+                getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y)
+            ];
+        simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
+        simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
+        simulateTouchEvent([], eventHolder, 'touchend'); // it can correctly trigger panend event.
+
+        expect(xaxis.min).toBe(initialXmin);
+        expect(xaxis.max).toBe(initialXmax);
+        expect(yaxis.min).toBe(initialYmin);
+        expect(yaxis.max).toBe(initialYmax);
+
+        options.pan.touchMode = oldTouchMode;
+      });
+
       it('should drag the logarithmic plot', function() {
           var d1 = [];
           for (var i = 0; i < 14; i += 0.2) {

--- a/tests/jquery.flot.touchNavigate.Test.js
+++ b/tests/jquery.flot.touchNavigate.Test.js
@@ -389,8 +389,8 @@ describe("flot touch navigate plugin", function () {
 
         plot = $.plot(placeholder, [
             [
-                [-10, 120],
-                [-10, 120]
+                [-10, -10],
+                [120, 120]
             ]
         ], options);
 
@@ -403,8 +403,116 @@ describe("flot touch navigate plugin", function () {
             initialYmax = yaxis.max,
             canvasCoords = [ { x : 1, y : 1 }, { x : 100, y : 100 }],
             pointCoords = [
-                    getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
-                    getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y)
+                getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
+                getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y)
+            ];
+        simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
+        simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
+        simulate.touchend(eventHolder, pointCoords[1].x, pointCoords[1].y);
+
+        expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[1].x), 6);
+        expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
+        expect(yaxis.min).toBeCloseTo(initialYmin + (canvasCoords[0].y - canvasCoords[1].y), 6);
+        expect(yaxis.max).toBeCloseTo(initialYmax + (canvasCoords[0].y - canvasCoords[1].y), 6);
+      });
+
+      it('should snap horizontal drag to x direction in smart pan mode', function() {
+        var oldTouchMode = options.pan.touchMode;
+        options.pan.touchMode = 'smart';
+
+        plot = $.plot(placeholder, [
+            [
+                [-10, -10],
+                [120, 120]
+            ]
+        ], options);
+
+        var eventHolder = plot.getEventHolder(),
+            xaxis = plot.getXAxes()[0],
+            yaxis = plot.getYAxes()[0];
+
+        var initialXmin = xaxis.min,
+            initialXmax = xaxis.max,
+            initialYmin = yaxis.min,
+            initialYmax = yaxis.max,
+            canvasCoords = [ { x : 1, y : 1 }, { x : 100, y : 2 }],
+            pointCoords = [
+                getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
+                getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y)
+            ];
+
+        simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
+        simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
+        simulate.touchend(eventHolder, pointCoords[1].x, pointCoords[1].y);
+
+        expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[1].x), 6);
+        expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
+        expect(yaxis.min).toBe(initialYmin);
+        expect(yaxis.max).toBe(initialYmax);
+
+        options.pan.touchMode = oldTouchMode;
+      });
+
+      it('should snap vertical drag to x direction in smart pan mode', function() {
+        var oldTouchMode = options.pan.touchMode;
+        options.pan.touchMode = 'smart';
+
+        plot = $.plot(placeholder, [
+            [
+                [-10, -10],
+                [120, 120]
+            ]
+        ], options);
+
+        var eventHolder = plot.getEventHolder(),
+            xaxis = plot.getXAxes()[0],
+            yaxis = plot.getYAxes()[0];
+
+        var initialXmin = xaxis.min,
+            initialXmax = xaxis.max,
+            initialYmin = yaxis.min,
+            initialYmax = yaxis.max,
+            canvasCoords = [ { x : 1, y : 1 }, { x : 2, y : 100 }],
+            pointCoords = [
+                getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
+                getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y)
+            ];
+
+        simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
+        simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
+        simulate.touchend(eventHolder, pointCoords[1].x, pointCoords[1].y);
+
+        expect(xaxis.min).toBe(initialXmin);
+        expect(xaxis.max).toBe(initialXmax);
+        expect(yaxis.min).toBeCloseTo(initialYmin + (canvasCoords[0].y - canvasCoords[1].y), 6);
+        expect(yaxis.max).toBeCloseTo(initialYmax + (canvasCoords[0].y - canvasCoords[1].y), 6);
+
+        options.pan.touchMode = oldTouchMode;
+      });
+
+      it('should no snap diagonal drag in smart pan mode', function() {
+        var oldTouchMode = options.pan.touchMode;
+        options.pan.touchMode = 'smart';
+
+        plot = $.plot(placeholder, [
+            [
+                [-10, -10],
+                [120, 120]
+            ]
+        ], options);
+
+        var eventHolder = plot.getEventHolder(),
+            xaxis = plot.getXAxes()[0],
+            yaxis = plot.getYAxes()[0];
+
+        var initialXmin = xaxis.min,
+            initialXmax = xaxis.max,
+            initialYmin = yaxis.min,
+            initialYmax = yaxis.max,
+            canvasCoords = [ { x : 1, y : 1 }, { x : 100, y : 100 }],
+            pointCoords = [
+                getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
+                getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y)
             ];
 
         simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
@@ -415,6 +523,86 @@ describe("flot touch navigate plugin", function () {
         expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
         expect(yaxis.min).toBeCloseTo(initialYmin + (canvasCoords[0].y - canvasCoords[1].y), 6);
         expect(yaxis.max).toBeCloseTo(initialYmax + (canvasCoords[0].y - canvasCoords[1].y), 6);
+
+        options.pan.touchMode = oldTouchMode;
+      });
+
+      it('should snap horizontally-start-drag to x direction in smartLock pan mode', function() {
+        var oldTouchMode = options.pan.touchMode;
+        options.pan.touchMode = 'smartLock';
+
+        plot = $.plot(placeholder, [
+            [
+                [-10, -10],
+                [120, 120]
+            ]
+        ], options);
+
+        var eventHolder = plot.getEventHolder(),
+            xaxis = plot.getXAxes()[0],
+            yaxis = plot.getYAxes()[0];
+
+        var initialXmin = xaxis.min,
+            initialXmax = xaxis.max,
+            initialYmin = yaxis.min,
+            initialYmax = yaxis.max,
+            canvasCoords = [ { x : 1, y : 1 }, { x : 100, y : 2 }, { x: 100, y: 100 }],
+            pointCoords = [
+                    getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
+                    getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y),
+                    getPairOfCoords(xaxis, yaxis, canvasCoords[2].x, canvasCoords[2].y)
+            ];
+        
+        simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
+        simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
+        simulate.touchmove(eventHolder, pointCoords[2].x, pointCoords[2].y);
+        simulate.touchend(eventHolder, pointCoords[2].x, pointCoords[2].y);
+
+        expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[1].x), 6);
+        expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
+        expect(yaxis.min).toBe(initialYmin);
+        expect(yaxis.max).toBe(initialYmax);
+
+        options.pan.touchMode = oldTouchMode;
+      });
+
+      it('should snap vertically-start-drag to y direction in smartLock pan mode', function() {
+        var oldTouchMode = options.pan.touchMode;
+        options.pan.touchMode = 'smartLock';
+
+        plot = $.plot(placeholder, [
+            [
+                [-10, -10],
+                [120, 120]
+            ]
+        ], options);
+
+        var eventHolder = plot.getEventHolder(),
+            xaxis = plot.getXAxes()[0],
+            yaxis = plot.getYAxes()[0];
+
+        var initialXmin = xaxis.min,
+            initialXmax = xaxis.max,
+            initialYmin = yaxis.min,
+            initialYmax = yaxis.max,
+            canvasCoords = [ { x : 1, y : 1 }, { x : 2, y : 100 }, { x: 100, y: 100 }],
+            pointCoords = [
+                getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
+                getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y),
+                getPairOfCoords(xaxis, yaxis, canvasCoords[2].x, canvasCoords[2].y)
+            ];
+
+        simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
+        simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
+        simulate.touchmove(eventHolder, pointCoords[2].x, pointCoords[2].y);
+        simulate.touchend(eventHolder, pointCoords[2].x, pointCoords[2].y);
+
+        expect(xaxis.min).toBe(initialXmin);
+        expect(xaxis.max).toBe(initialXmax);
+        expect(yaxis.min).toBeCloseTo(initialYmin + (canvasCoords[0].y - canvasCoords[1].y), 6);
+        expect(yaxis.max).toBeCloseTo(initialYmax + (canvasCoords[0].y - canvasCoords[1].y), 6);
+
+        options.pan.touchMode = oldTouchMode;
       });
 
       it('should drag the logarithmic plot', function() {
@@ -671,7 +859,7 @@ describe("flot touch navigate plugin", function () {
               ]
           ], {
               xaxes: [{ autoScale: 'exact', plotPan: false }],
-              yaxes: [{ autoScale: 'exact' }],
+              yaxes: [{ autoScale: 'exact', plotPan: false }],
               zoom: { interactive: true, active: true, amount: 10 },
               pan: { interactive: true, active: true, frameRate: -1, enableTouch: true }
           });
@@ -682,8 +870,8 @@ describe("flot touch navigate plugin", function () {
               initialXmin = xaxis.min,
               initialXmax = xaxis.max,
               pointCoords = [
-                      { x: 0, y: 10 },
-                      { x: 5, y: 15 }
+                      { x: 0, y: 50 },
+                      { x: 50, y: 100 }
               ];
 
           simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
@@ -692,7 +880,7 @@ describe("flot touch navigate plugin", function () {
           simulate.touchend(eventHolder, pointCoords[1].x, pointCoords[1].y);
 
           expect(xaxis.min).toBe(0);
-          expect(yaxis.max).toBe(10);
+          expect(xaxis.max).toBe(10);
           expect(yaxis.min).toBe(0);
           expect(yaxis.max).toBe(10);
       });

--- a/tests/jquery.flot.touchNavigate.Test.js
+++ b/tests/jquery.flot.touchNavigate.Test.js
@@ -408,7 +408,7 @@ describe("flot touch navigate plugin", function () {
             ];
         simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
         simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
-        simulate.touchend(eventHolder, pointCoords[1].x, pointCoords[1].y);
+        simulateTouchEvent([], eventHolder, 'touchend'); // it can correctly trigger panend event.
 
         expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[1].x), 6);
         expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
@@ -443,7 +443,7 @@ describe("flot touch navigate plugin", function () {
 
         simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
         simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
-        simulate.touchend(eventHolder, pointCoords[1].x, pointCoords[1].y);
+        simulateTouchEvent([], eventHolder, 'touchend'); // it can correctly trigger panend event.
 
         expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[1].x), 6);
         expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
@@ -480,7 +480,7 @@ describe("flot touch navigate plugin", function () {
 
         simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
         simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
-        simulate.touchend(eventHolder, pointCoords[1].x, pointCoords[1].y);
+        simulateTouchEvent([], eventHolder, 'touchend'); // it can correctly trigger panend event.
 
         expect(xaxis.min).toBe(initialXmin);
         expect(xaxis.max).toBe(initialXmax);
@@ -517,7 +517,7 @@ describe("flot touch navigate plugin", function () {
 
         simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
         simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
-        simulate.touchend(eventHolder, pointCoords[1].x, pointCoords[1].y);
+        simulateTouchEvent([], eventHolder, 'touchend'); // it can correctly trigger panend event.
 
         expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[1].x), 6);
         expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
@@ -556,7 +556,7 @@ describe("flot touch navigate plugin", function () {
         simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
         simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
         simulate.touchmove(eventHolder, pointCoords[2].x, pointCoords[2].y);
-        simulate.touchend(eventHolder, pointCoords[2].x, pointCoords[2].y);
+        simulateTouchEvent([], eventHolder, 'touchend'); // it can correctly trigger panend event.
 
         expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[1].x), 6);
         expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
@@ -595,7 +595,7 @@ describe("flot touch navigate plugin", function () {
         simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
         simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
         simulate.touchmove(eventHolder, pointCoords[2].x, pointCoords[2].y);
-        simulate.touchend(eventHolder, pointCoords[2].x, pointCoords[2].y);
+        simulateTouchEvent([], eventHolder, 'touchend'); // it can correctly trigger panend event.
 
         expect(xaxis.min).toBe(initialXmin);
         expect(xaxis.max).toBe(initialXmax);
@@ -986,6 +986,48 @@ describe("flot touch navigate plugin", function () {
           expect(xaxis.max).toBeCloseTo(initialXmax, 6);
           expect(yaxis.min).toBeCloseTo(initialYmin, 6);
           expect(yaxis.max).toBeCloseTo(initialYmax, 6);
+
+        });
+
+        it('should not recenter for doubletap event triggered by touchmove', function() {
+          //when touchmove to somewhere close to last doubletap point, another doubletap will be triggered
+          //this doubletap event should not do recenter
+          plot = $.plot(placeholder, [
+              [
+                  [-10, 120],
+                  [-10, 120]
+              ]
+          ], options);
+          var eventHolder = plot.getEventHolder(),
+          xaxis = plot.getXAxes()[0],
+          yaxis = plot.getYAxes()[0],
+          initialXmin = xaxis.min,
+          initialXmax = xaxis.max,
+          initialYmin = yaxis.min,
+          initialYmax = yaxis.max,
+          canvasCoords = [ { x : 1, y : 2 }, { x : 3, y : 5 }],
+          pointCoords = [
+                  getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
+                  getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y)
+          ];
+
+          //simulate double tap
+          simulate.touchstart(eventHolder, pointCoords[1].x, pointCoords[1].y);
+          simulate.touchend(eventHolder, pointCoords[1].x, pointCoords[1].y);
+          simulate.touchstart(eventHolder, pointCoords[1].x, pointCoords[1].y);
+          simulate.touchend(eventHolder, pointCoords[1].x, pointCoords[1].y);
+
+          //drag the plot
+          simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
+          simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
+          
+          //check if the drag modified the plot correctly
+          expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[1].x), 6);
+          expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
+          expect(yaxis.min).toBeCloseTo(initialYmin + (canvasCoords[0].y - canvasCoords[1].y), 6);
+          expect(yaxis.max).toBeCloseTo(initialYmax + (canvasCoords[0].y - canvasCoords[1].y), 6);
+
+          simulate.touchend(eventHolder, pointCoords[1].x, pointCoords[1].y);
 
         });
 


### PR DESCRIPTION
Enables three types of drag/pan interaction behavior: ‘normal’ (tentative naming), smart, and smart-lock.

Add pan mode option to customize the mouse drag interaction behavior.
Add pan touchMode option to customize the touch pan interaction behavior.

This change is moved from engineering-flot PR: https://github.com/ni-kismet/engineering-flot/pull/279.

@andrewdove1, now I need your comments to decide **whether we should change the default behavior and merge two mode options into one**. FYI, the origin default (fixed) behavior is that mouse interaction does smart pan, while touch interaction does 'normal' pan.