### PR TITLE
jquery.flot.navigate.js: Reinitialize prevDelta after dragging ends

### DIFF
--- a/source/jquery.flot.navigate.js
+++ b/source/jquery.flot.navigate.js
@@ -298,6 +298,7 @@ can set the default in the options.
                 y: plotState.startPageY - page.Y
             }, plotState, panAxes);
             panHint = null;
+            prevDelta = { x: 0, y: 0 };
         }
 
         function onDblClick(e) {


### PR DESCRIPTION
When intermediate pans are disabled (frameRate is null), each pan is nullified by the subsequent pan in **plot.smartPan**.

Since prevDelta is not reinitialized after the previous pan ended (onDragEnd)
`d = delta[axis.direction];`
`p = prevDelta[axis.direction];`

causes
`(p - d)` to always be zero (if frameRate == null) in plot.smartPan:
`navigationOffsetBelow = saturated.saturate(axis.c2p(axis.p2c(axisMin) - (p - d)) ...` `navigationOffsetAbove = saturated.saturate(axis.c2p(axis.p2c(axisMax) - (p - d)) ...`

which causes unexpected results on the subsequent pans.