### PR TITLE
jquery.flot.selection.js: reinitialize current mode in onMouseDown to…

### DIFF
--- a/source/jquery.flot.selection.js
+++ b/source/jquery.flot.selection.js
@@ -111,6 +111,9 @@ The plugin allso adds the following methods to the plot object:
             // only accept left-click
             if (e.which !== 1) return;
 
+            // reinitialize currentMode
+            selection.currentMode = 'xy';
+
             // cancel out any text selections
             document.body.focus();
 


### PR DESCRIPTION
… fix unexpected behavior when 'smart' mode is enabled:

When smart mode is enabled, selection plug-in behaves unexpectedly. Steps to reproduce:

1. Enable smart mode
1. Click anywhere on the chart (> minSize pixels away from upper left corner)
1. Click on that point again
1. Click on that point yet again

**Results**
After second click:
![flot_smart_selection_01](https://user-images.githubusercontent.com/14980771/52943541-aab5be00-336d-11e9-8f77-b135586005bc.png)
After third click:
![flot_smart_selection_02](https://user-images.githubusercontent.com/14980771/52943542-aab5be00-336d-11e9-8020-d2a1eddaa66b.png)

This is fixed by reinitializing selection.currentMode to 'xy' in function onMouseDown.
