### PR TITLE
Removed creation of intermediate datapoints from trailing step algorithm

### DIFF
--- a/source/jquery.flot.drawSeries.js
+++ b/source/jquery.flot.drawSeries.js
@@ -10,7 +10,7 @@ This plugin is used by flot for drawing lines, plots, bars or area.
     "use strict";
 
     function DrawSeries() {
-        function plotLine(datapoints, xoffset, yoffset, axisx, axisy, ctx) {
+        function plotLine(datapoints, xoffset, yoffset, axisx, axisy, ctx, steps) {
             var points = datapoints.points,
                 ps = datapoints.pointsize,
                 prevx = null,
@@ -19,6 +19,8 @@ This plugin is used by flot for drawing lines, plots, bars or area.
                 y1 = 0.0,
                 x2 = 0.0,
                 y2 = 0.0,
+                mx = null,
+                my = null,
                 i = 0;
 
             ctx.beginPath();
@@ -29,7 +31,32 @@ This plugin is used by flot for drawing lines, plots, bars or area.
                 y2 = points[i + 1];
 
                 if (x1 === null || x2 === null) {
+                    console.log('MP:',mx,my);
+                    mx = null;
+                    my = null;
                     continue;
+                }
+
+                if(steps){
+                    if (mx !== null && my !== null) {
+                        // if middle point exists, transfer p2 -> p1 and p1 -> mp
+                        x2 = x1;
+                        y2 = y1;
+                        x1 = mx;
+                        y1 = my;
+
+                        // 'remove' middle point
+                        mx = null;
+                        my = null;
+
+                        // subtract pointsize from i to have current point p1 handled again
+                        i -= ps;
+                    } else if (y1 !== y2 && x1 !== x2) {
+                        // create a middle point
+                        y2 = y1;
+                        mx = x2;
+                        my = y1;
+                    }
                 }
 
                 // clip with ymin
@@ -112,7 +139,7 @@ This plugin is used by flot for drawing lines, plots, bars or area.
             ctx.stroke();
         }
 
-        function plotLineArea(datapoints, axisx, axisy, fillTowards, ctx) {
+        function plotLineArea(datapoints, axisx, axisy, fillTowards, ctx, steps) {
             var points = datapoints.points,
                 ps = datapoints.pointsize,
                 bottom = fillTowards > axisy.min ? Math.min(axisy.max, fillTowards) : axisy.min,
@@ -120,7 +147,9 @@ This plugin is used by flot for drawing lines, plots, bars or area.
                 ypos = 1,
                 areaOpen = false,
                 segmentStart = 0,
-                segmentEnd = 0;
+                segmentEnd = 0,
+                mx = null,
+                my = null;
 
             // we process each segment in two turns, first forward
             // direction to sketch out top, then once we hit the
@@ -162,7 +191,31 @@ This plugin is used by flot for drawing lines, plots, bars or area.
                 }
 
                 if (x1 == null || x2 == null) {
+                    mx = null;
+                    my = null;
                     continue;
+                }
+
+                if(steps){
+                    if (mx !== null && my !== null) {
+                        // if middle point exists, transfer p2 -> p1 and p1 -> mp
+                        x2 = x1;
+                        y2 = y1;
+                        x1 = mx;
+                        y1 = my;
+
+                        // 'remove' middle point
+                        mx = null;
+                        my = null;
+
+                        // subtract pointsize from i to have current point p1 handled again
+                        i -= ps;
+                    } else if (y1 !== y2 && x1 !== x2) {
+                        // create a middle point
+                        y2 = y1;
+                        mx = x2;
+                        my = y1;
+                    }
                 }
 
                 // clip x values
@@ -304,11 +357,11 @@ This plugin is used by flot for drawing lines, plots, bars or area.
             var fillStyle = getFillStyle(series.lines, series.color, 0, plotHeight, getColorOrGradient);
             if (fillStyle) {
                 ctx.fillStyle = fillStyle;
-                plotLineArea(datapoints, series.xaxis, series.yaxis, series.lines.fillTowards || 0, ctx);
+                plotLineArea(datapoints, series.xaxis, series.yaxis, series.lines.fillTowards || 0, ctx, series.lines.steps);
             }
 
             if (lw > 0) {
-                plotLine(datapoints, 0, 0, series.xaxis, series.yaxis, ctx);
+                plotLine(datapoints, 0, 0, series.xaxis, series.yaxis, ctx, series.lines.steps);
             }
 
             ctx.restore();

--- a/source/jquery.flot.drawSeries.js
+++ b/source/jquery.flot.drawSeries.js
@@ -31,7 +31,6 @@ This plugin is used by flot for drawing lines, plots, bars or area.
                 y2 = points[i + 1];
 
                 if (x1 === null || x2 === null) {
-                    console.log('MP:',mx,my);
                     mx = null;
                     my = null;
                     continue;

--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -892,25 +892,6 @@ Licensed under the MIT license.
                             }
                             points[k + m] = null;
                         }
-                    } else {
-                        // a little bit of line specific stuff that
-                        // perhaps shouldn't be here, but lacking
-                        // better means...
-                        if (insertSteps && k > 0 &&
-                            points[k - ps] != null &&
-                            points[k - ps] !== points[k] &&
-                            points[k - ps + 1] !== points[k + 1]) {
-                            // copy the point to make room for a middle point
-                            for (m = 0; m < ps; ++m) {
-                                points[k + ps + m] = points[k + m];
-                            }
-
-                            // middle point has same y
-                            points[k + 1] = points[k - ps + 1];
-
-                            // we've added a point, better reflect that
-                            k += ps;
-                        }
                     }
                 }
 

--- a/tests/jquery.flot-drawSeries.Test.js
+++ b/tests/jquery.flot-drawSeries.Test.js
@@ -114,6 +114,33 @@ describe('drawSeries', function() {
                     ctx.lineTo.calls.allArgs()));
         });
 
+        it('should draw the lines when trailing step interpolation is enabled', function () {
+            series.datapoints.points = [0, 0, 150, 25, 50, 75, 200, 100];
+            series.lines.steps = true;
+
+            spyOn(ctx, 'lineTo').and.callThrough();
+
+            drawSeriesLines(series, ctx, plotOffset, plotWidth, plotHeight, null, getColorOrGradient);
+
+            expect(ctx.lineTo).toHaveBeenCalled();
+        });
+
+        it('should fill the area when trailing step interpolation is enabled', function () {
+            series.datapoints.points = [0, 0, 150, 25, 50, 75, 200, 100];
+            series.lines.steps = true;
+            series.lines.fill = true;
+            series.lines.lineWidth = 0;
+
+            spyOn(ctx, 'moveTo').and.callThrough();
+            spyOn(ctx, 'lineTo').and.callThrough();
+            spyOn(ctx, 'fill').and.callThrough();
+
+            drawSeriesLines(series, ctx, plotOffset, plotWidth, plotHeight, null, getColorOrGradient);
+
+            expect(ctx.moveTo).toHaveBeenCalled();
+            expect(ctx.lineTo).toHaveBeenCalled();
+            expect(ctx.fill).toHaveBeenCalled();
+        });
 
         function validatePointsAreInsideTheAxisRanges(points) {
             points.forEach(function(point) {


### PR DESCRIPTION
Moved the implementation of the trailing steps to jquery.flot.drawSeries.js (plotLine function) to draw the trailing step without having to create intermediate points that are not present in the original dataset.

Also, added similar modification to the plotLineArea function (for "filled" lines).