### PR TITLE
fix flot-svg layer display issue on iOS

### DIFF
--- a/source/jquery.canvaswrapper.js
+++ b/source/jquery.canvaswrapper.js
@@ -198,8 +198,8 @@ don't work unless the canvas is attached to the DOM.
                 this.SVGContainer.style.position = 'absolute';
                 this.SVGContainer.style.top = '0px';
                 this.SVGContainer.style.left = '0px';
-                this.SVGContainer.style.bottom = '0px';
-                this.SVGContainer.style.right = '0px';
+                this.SVGContainer.style.height = '100%';
+                this.SVGContainer.style.width = '100%';
                 this.SVGContainer.style.pointerEvents = 'none';
                 this.element.parentNode.appendChild(this.SVGContainer);
 


### PR DESCRIPTION
What's the problem?
-----------------------
Sometimes the svg container inside the flot-svg div doesn't fit to the parent container 100% on iOS ~~Safari~~(I also see this issue on Chrome, Firefox on iOS). See the picture below
![image](https://user-images.githubusercontent.com/9316149/53392814-82653980-39d5-11e9-93e4-a282e009f334.png)
![image](https://user-images.githubusercontent.com/9316149/53392830-8beea180-39d5-11e9-9a93-b1b1bd225b7a.png)
From the pictures we can see that the height of the svg element is 100% but it doesn't fit to its parent container which is the HTML div element with class "flot-svg". 

Why does it happen?
------------------------
I use [remotedebug-ios-webkit-adapter](https://github.com/RemoteDebug/remotedebug-ios-webkit-adapter#usage-with-chrome-canary-and-chrome-devtools) to debug this issue on the iPad. When I pan the graph area, I can see the svg element's height changes. Because the svg element's height is 100% of its parent so I suspect that its parent flot-svg HTMLDIV element's height is not stable in the composition phase when panning the graph area. Then I select this element in the chrome devtools and indeed see its height changes. the flot-svg element is a absolutely positioned element that is made to fill the available vertical space by specifying both top and bottom as 0. See the MDN position [documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/position) there is a statement: 
"Most of the time, absolutely positioned elements that have height and width set to auto are sized so as to fit their contents. However, non-replaced, absolutely positioned elements can be made to fill the available vertical space by specifying both top and bottom and leaving height unspecified (that is, auto). They can likewise be made to fill the available horizontal space by specifying both left and right and leaving width as auto."
It seems that the browsers on iOS ~~Safari~~ has problem on this rule in some case.

How to fix it?
---------------
Set the height and width of the flot-svg element to 100% to fit its parent.