### PR TITLE
Fix for error when changing axis to log when it has no data.

### DIFF
--- a/source/jquery.flot.logaxis.js
+++ b/source/jquery.flot.logaxis.js
@@ -249,7 +249,9 @@ formatters and transformers to and from logarithmic representation.
                 .map(function(series) {
                     return plot.computeRangeForDataSeries(series, null, isValid);
                 }),
-            min = axis.direction === 'x' ? Math.min(0.1, range[0].xmin) : Math.min(0.1, range[0].ymin);
+            min = axis.direction === 'x' 
+            ? Math.min(0.1, range && range[0] ? range[0].xmin : 0.1) 
+            : Math.min(0.1, range && range[0] ? range[0].ymin : 0.1);
 
         axis.min = min;
 

--- a/tests/jquery.flot.logaxis.Test.js
+++ b/tests/jquery.flot.logaxis.Test.js
@@ -170,6 +170,29 @@ describe("unit tests for the log scale functions", function() {
         expect(axis.min).toBe(0.1);
         expect(axis.max).toBe(1);
     });
+
+    it('should set min of axis with no data associated with it to be greater than 0', function() {
+        var plot = $.plot(placeholder, [[0, 1, 2, 3]], {
+                xaxes: [
+                    {
+                        mode: 'log',
+                        min: 0,
+                        max: 10
+                    },
+                    {
+                        mode: 'log',
+                        autoScale: 'loose',
+                        min: 0,
+                        max: 10,
+                        show: true
+                    }]
+            }),
+            axis,
+
+        axis = plot.getXAxes()[1];
+
+        expect(axis.min).toBeGreaterThan(0);
+    });
 });
 
 describe("integration tests for log scale functions", function() {


### PR DESCRIPTION
This issue would only arise when there were multiple axes of a particular orientation and a non-default axis had no data associated with it.