### PR TITLE
Make it possible to disable pinch reaction

### DIFF
--- a/docs/navigate.md
+++ b/docs/navigate.md
@@ -13,7 +13,8 @@ The plugin supports these options:
     zoom: {
         interactive: false,
         active: false,
-        amount: 1.5         // 2 = 200% (zoom in), 0.5 = 50% (zoom out)
+        amount: 1.5,         // 2 = 200% (zoom in), 0.5 = 50% (zoom out)
+        enableTouch: false
     }
 
     pan: {

--- a/examples/navigateTouch/index.html
+++ b/examples/navigateTouch/index.html
@@ -107,7 +107,8 @@
                     autoScale: 'exact'
                 },
                 zoom: {
-                    interactive: true
+                    interactive: true,
+                    enableTouch: true
                 },
                 pan: {
                     interactive: true,
@@ -154,7 +155,8 @@
                 yaxes: [ { mode: 'log', showTickLabels: 'all', autoScale: 'exact'},
                         { mode: 'log', showTickLabels: 'all', autoScale: 'exact'} ],
                 zoom: {
-                    interactive: true
+                    interactive: true,
+                    enableTouch: true
                 },
                 pan: {
                     interactive: true,

--- a/source/jquery.flot.touch.js
+++ b/source/jquery.flot.touch.js
@@ -5,9 +5,6 @@
     'use strict';
 
     var options = {
-        pan: {
-            enableTouch: false
-        }
     };
 
     function init(plot) {
@@ -221,7 +218,7 @@
             }
         };
 
-        if (options.pan.enableTouch === true) {
+        if (options.pan.enableTouch === true || options.zoom.enableTouch) {
             plot.hooks.bindEvents.push(bindEvents);
             plot.hooks.shutdown.push(shutdown);
         };

--- a/source/jquery.flot.touchNavigate.js
+++ b/source/jquery.flot.touchNavigate.js
@@ -6,6 +6,7 @@
     var options = {
         pan: {
             enableTouch: false,
+            enablePinch: true,
             touchMode: 'manual'
         }
     };
@@ -43,9 +44,11 @@
                 eventHolder[0].addEventListener('panstart', pan.start, false);
                 eventHolder[0].addEventListener('pandrag', pan.drag, false);
                 eventHolder[0].addEventListener('panend', pan.end, false);
-                eventHolder[0].addEventListener('pinchstart', pinch.start, false);
-                eventHolder[0].addEventListener('pinchdrag', pinch.drag, false);
-                eventHolder[0].addEventListener('pinchend', pinch.end, false);
+                if (o.pan.enablePinch) {
+                    eventHolder[0].addEventListener('pinchstart', pinch.start, false);
+                    eventHolder[0].addEventListener('pinchdrag', pinch.drag, false);
+                    eventHolder[0].addEventListener('pinchend', pinch.end, false);
+                }
                 eventHolder[0].addEventListener('doubletap', doubleTap.recenterPlot, false);
             }
         }

--- a/source/jquery.flot.touchNavigate.js
+++ b/source/jquery.flot.touchNavigate.js
@@ -4,9 +4,11 @@
     'use strict';
 
     var options = {
+        zoom: {
+            enableTouch: false
+        },
         pan: {
             enableTouch: false,
-            enablePinch: true,
             touchMode: 'manual'
         }
     };
@@ -32,23 +34,24 @@
                 navigationConstraint: 'unconstrained',
                 initialState: null,
             },
-            useManualPan = options.pan.touchMode === 'manual',
+            useManualPan = options.pan.interactive && options.pan.enableTouch && options.pan.touchMode === 'manual',
             smartPanLock = options.pan.touchMode === 'smartLock',
-            useSmartPan = smartPanLock || options.pan.touchMode === 'smart',
+            useSmartPan = options.pan.interactive && options.pan.enableTouch && (smartPanLock || options.pan.touchMode === 'smart'),
             pan, pinch, doubleTap;
 
         function bindEvents(plot, eventHolder) {
             var o = plot.getOptions();
 
+            if (o.zoom.interactive && o.zoom.enableTouch) {
+                eventHolder[0].addEventListener('pinchstart', pinch.start, false);
+                eventHolder[0].addEventListener('pinchdrag', pinch.drag, false);
+                eventHolder[0].addEventListener('pinchend', pinch.end, false);
+            }
+
             if (o.pan.interactive) {
                 eventHolder[0].addEventListener('panstart', pan.start, false);
                 eventHolder[0].addEventListener('pandrag', pan.drag, false);
                 eventHolder[0].addEventListener('panend', pan.end, false);
-                if (o.pan.enablePinch) {
-                    eventHolder[0].addEventListener('pinchstart', pinch.start, false);
-                    eventHolder[0].addEventListener('pinchdrag', pinch.drag, false);
-                    eventHolder[0].addEventListener('pinchend', pinch.end, false);
-                }
                 eventHolder[0].addEventListener('doubletap', doubleTap.recenterPlot, false);
             }
         }
@@ -144,8 +147,6 @@
                         });
                         updatePrevPanPosition(e, 'pinch', gestureState, navigationState);
                     }
-
-
 
                     var dist = pinchDistance(e);
 

--- a/source/jquery.flot.touchNavigate.js
+++ b/source/jquery.flot.touchNavigate.js
@@ -119,11 +119,6 @@
                 presetNavigationState(e, 'pinch', gestureState);
                 setPrevDistance(e, gestureState);
                 updateData(e, 'pinch', gestureState, navigationState);
-
-                if (useSmartPan) {
-                    var point = getPoint(e, 'pinch');
-                    navigationState.initialState = plot.navigationState(point.x, point.y);
-                }
             },
 
             drag: function(e) {
@@ -133,20 +128,12 @@
                 pinchDragTimeout = setTimeout(function() {
                     presetNavigationState(e, 'pinch', gestureState);
 
-                    if (useSmartPan) {
-                        var point = getPoint(e, 'pinch');
-                        plot.smartPan({
-                            x: navigationState.initialState.startPageX - point.x,
-                            y: navigationState.initialState.startPageY - point.y
-                        }, navigationState.initialState, navigationState.touchedAxis, false, smartPanLock);
-                    } else if (useManualPan) {
-                        plot.pan({
-                            left: -delta(e, 'pinch', gestureState).x,
-                            top: -delta(e, 'pinch', gestureState).y,
-                            axes: navigationState.touchedAxis
-                        });
-                        updatePrevPanPosition(e, 'pinch', gestureState, navigationState);
-                    }
+                    plot.pan({
+                        left: -delta(e, 'pinch', gestureState).x,
+                        top: -delta(e, 'pinch', gestureState).y,
+                        axes: navigationState.touchedAxis
+                    });
+                    updatePrevPanPosition(e, 'pinch', gestureState, navigationState);
 
                     var dist = pinchDistance(e);
 
@@ -167,10 +154,6 @@
                 }
                 presetNavigationState(e, 'pinch', gestureState);
                 gestureState.prevDistance = null;
-
-                if (useSmartPan) {
-                    plot.smartPan.end();
-                }
             }
         };
 
@@ -184,7 +167,7 @@
             }
         };
 
-        if (options.pan.enableTouch === true) {
+        if (options.pan.enableTouch === true || options.zoom.enableTouch === true) {
             plot.hooks.bindEvents.push(bindEvents);
             plot.hooks.shutdown.push(shutdown);
         }

--- a/source/jquery.flot.touchNavigate.js
+++ b/source/jquery.flot.touchNavigate.js
@@ -113,6 +113,11 @@
                 presetNavigationState(e, 'pinch', gestureState);
                 setPrevDistance(e, gestureState);
                 updateData(e, 'pinch', gestureState, navigationState);
+
+                if (useSmartPan) {
+                    var point = getPoint(e, 'pinch');
+                    navigationState.initialState = plot.navigationState(point.x, point.y);
+                }
             },
 
             drag: function(e) {
@@ -121,12 +126,23 @@
                 }
                 pinchDragTimeout = setTimeout(function() {
                     presetNavigationState(e, 'pinch', gestureState);
-                    plot.pan({
-                        left: -delta(e, 'pinch', gestureState).x,
-                        top: -delta(e, 'pinch', gestureState).y,
-                        axes: navigationState.touchedAxis
-                    });
-                    updatePrevPanPosition(e, 'pinch', gestureState, navigationState);
+
+                    if (useSmartPan) {
+                        var point = getPoint(e, 'pinch');
+                        plot.smartPan({
+                            x: navigationState.initialState.startPageX - point.x,
+                            y: navigationState.initialState.startPageY - point.y
+                        }, navigationState.initialState, navigationState.touchedAxis, false, smartPanLock);
+                    } else if (useManualPan) {
+                        plot.pan({
+                            left: -delta(e, 'pinch', gestureState).x,
+                            top: -delta(e, 'pinch', gestureState).y,
+                            axes: navigationState.touchedAxis
+                        });
+                        updatePrevPanPosition(e, 'pinch', gestureState, navigationState);
+                    }
+
+
 
                     var dist = pinchDistance(e);
 
@@ -147,6 +163,10 @@
                 }
                 presetNavigationState(e, 'pinch', gestureState);
                 gestureState.prevDistance = null;
+
+                if (useSmartPan) {
+                    plot.smartPan.end();
+                }
             }
         };
 

--- a/source/jquery.flot.touchNavigate.js
+++ b/source/jquery.flot.touchNavigate.js
@@ -34,9 +34,9 @@
                 navigationConstraint: 'unconstrained',
                 initialState: null,
             },
-            useManualPan = options.pan.interactive && options.pan.enableTouch && options.pan.touchMode === 'manual',
+            useManualPan = options.pan.interactive && options.pan.touchMode === 'manual',
             smartPanLock = options.pan.touchMode === 'smartLock',
-            useSmartPan = options.pan.interactive && options.pan.enableTouch && (smartPanLock || options.pan.touchMode === 'smart'),
+            useSmartPan = options.pan.interactive && (smartPanLock || options.pan.touchMode === 'smart'),
             pan, pinch, doubleTap;
 
         function bindEvents(plot, eventHolder) {
@@ -48,7 +48,7 @@
                 eventHolder[0].addEventListener('pinchend', pinch.end, false);
             }
 
-            if (o.pan.interactive) {
+            if (o.pan.interactive && o.pan.enableTouch) {
                 eventHolder[0].addEventListener('panstart', pan.start, false);
                 eventHolder[0].addEventListener('pandrag', pan.drag, false);
                 eventHolder[0].addEventListener('panend', pan.end, false);
@@ -127,7 +127,6 @@
                 }
                 pinchDragTimeout = setTimeout(function() {
                     presetNavigationState(e, 'pinch', gestureState);
-
                     plot.pan({
                         left: -delta(e, 'pinch', gestureState).x,
                         top: -delta(e, 'pinch', gestureState).y,

--- a/tests/jquery.flot.touchNavigate.Test.js
+++ b/tests/jquery.flot.touchNavigate.Test.js
@@ -352,7 +352,7 @@ describe("flot touch navigate plugin", function () {
             ], {
                 xaxes: [{ autoScale: 'exact', plotZoom: false, plotPan: false }],
                 yaxes: [{ autoScale: 'exact' }],
-                zoom: { interactive: true, active: true, amount: 10 },
+                zoom: { interactive: true, active: true, amount: 10, enableTouch: true },
                 pan: { interactive: true, active: true, frameRate: -1, enableTouch: true }
             });
 

--- a/tests/jquery.flot.touchNavigate.Test.js
+++ b/tests/jquery.flot.touchNavigate.Test.js
@@ -11,7 +11,7 @@ describe("flot touch navigate plugin", function () {
         options = {
             xaxes: [{ autoScale: 'exact' }],
             yaxes: [{ autoScale: 'exact' }],
-            zoom: { interactive: true, active: true, amount: 10 },
+            zoom: { interactive: true, active: true, amount: 10, enableTouch: true },
             pan: { interactive: true, active: true, frameRate: -1, enableTouch: true }
         };
         jasmine.clock().install();

--- a/tests/jquery.flot.touchNavigate.Test.js
+++ b/tests/jquery.flot.touchNavigate.Test.js
@@ -975,6 +975,90 @@ describe("flot touch navigate plugin", function () {
           expect(yaxis.min).toBe(previousYmin);
           expect(yaxis.max).toBe(previousYmax);
         });
+
+        it('can do smart pan for pinch move', function() {
+          var oldTouchMode = options.pan.touchMode;
+          options.pan.touchMode = 'smart';
+  
+          plot = $.plot(placeholder, [
+              [
+                  [-10, -10],
+                  [120, 120]
+              ]
+          ], options);
+  
+          var eventHolder = plot.getEventHolder(),
+              xaxis = plot.getXAxes()[0],
+              yaxis = plot.getYAxes()[0];
+  
+          var initialXmin = xaxis.min,
+              initialXmax = xaxis.max,
+              initialYmin = yaxis.min,
+              initialYmax = yaxis.max,
+              canvasCoords = [ { x : 1, y : 1 }, { x : 100, y : 5 }],
+              initialCoords = [
+                  getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
+                  getPairOfCoords(xaxis, yaxis, canvasCoords[0].x + 1, canvasCoords[0].y + 1),
+              ],
+              finalCoordsPinch = [
+                  getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y),
+                  getPairOfCoords(xaxis, yaxis, canvasCoords[1].x + 1, canvasCoords[1].y + 1),
+              ];
+
+          //simulate pinch
+          simulateTouchEvent(initialCoords, eventHolder, 'touchstart');
+          simulateTouchEvent(finalCoordsPinch, eventHolder, 'touchmove');
+          simulateTouchEvent(finalCoordsPinch, eventHolder, 'touchend');
+
+          expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[1].x), 6);
+          expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
+          expect(yaxis.min).toBe(initialYmin);
+          expect(yaxis.max).toBe(initialYmax);
+
+          options.pan.touchMode = oldTouchMode;
+        });
+
+        it('can disable pinch', function() {
+          var oldEnablePinch = options.pan.enablePinch;
+          options.pan.enablePinch = false;
+
+          plot = $.plot(placeholder, [
+            [
+                [-10, -10],
+                [120, 120]
+            ]
+          ], options);
+
+          var eventHolder = plot.getEventHolder(),
+          xaxis = plot.getXAxes()[0],
+          yaxis = plot.getYAxes()[0];
+
+          var initialXmin = xaxis.min,
+              initialXmax = xaxis.max,
+              initialYmin = yaxis.min,
+              initialYmax = yaxis.max,
+              canvasCoords = [ { x : 1, y : 1 }, { x : 100, y : 5 }],
+              initialCoords = [
+                  getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
+                  getPairOfCoords(xaxis, yaxis, canvasCoords[0].x + 1, canvasCoords[0].y + 1),
+              ],
+              finalCoordsPinch = [
+                  getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y),
+                  getPairOfCoords(xaxis, yaxis, canvasCoords[1].x + 1, canvasCoords[1].y + 1),
+              ];
+
+          //simulate pinch
+          simulateTouchEvent(initialCoords, eventHolder, 'touchstart');
+          simulateTouchEvent(finalCoordsPinch, eventHolder, 'touchmove');
+          simulateTouchEvent(finalCoordsPinch, eventHolder, 'touchend');
+
+          expect(xaxis.min).toBe(initialXmin);
+          expect(xaxis.max).toBe(initialXmax);
+          expect(yaxis.min).toBe(initialYmin);
+          expect(yaxis.max).toBe(initialYmax);
+
+          options.pan.enablePinch = oldEnablePinch;
+        })
     });
 
     describe('doubleTap', function() {

--- a/tests/jquery.flot.touchNavigate.Test.js
+++ b/tests/jquery.flot.touchNavigate.Test.js
@@ -976,51 +976,9 @@ describe("flot touch navigate plugin", function () {
           expect(yaxis.max).toBe(previousYmax);
         });
 
-        it('can do smart pan for pinch move', function() {
-          var oldTouchMode = options.pan.touchMode;
-          options.pan.touchMode = 'smart';
-  
-          plot = $.plot(placeholder, [
-              [
-                  [-10, -10],
-                  [120, 120]
-              ]
-          ], options);
-  
-          var eventHolder = plot.getEventHolder(),
-              xaxis = plot.getXAxes()[0],
-              yaxis = plot.getYAxes()[0];
-  
-          var initialXmin = xaxis.min,
-              initialXmax = xaxis.max,
-              initialYmin = yaxis.min,
-              initialYmax = yaxis.max,
-              canvasCoords = [ { x : 1, y : 1 }, { x : 100, y : 5 }],
-              initialCoords = [
-                  getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
-                  getPairOfCoords(xaxis, yaxis, canvasCoords[0].x + 1, canvasCoords[0].y + 1),
-              ],
-              finalCoordsPinch = [
-                  getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y),
-                  getPairOfCoords(xaxis, yaxis, canvasCoords[1].x + 1, canvasCoords[1].y + 1),
-              ];
-
-          //simulate pinch
-          simulateTouchEvent(initialCoords, eventHolder, 'touchstart');
-          simulateTouchEvent(finalCoordsPinch, eventHolder, 'touchmove');
-          simulateTouchEvent(finalCoordsPinch, eventHolder, 'touchend');
-
-          expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[1].x), 6);
-          expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
-          expect(yaxis.min).toBe(initialYmin);
-          expect(yaxis.max).toBe(initialYmax);
-
-          options.pan.touchMode = oldTouchMode;
-        });
-
         it('can disable pinch', function() {
-          var oldEnablePinch = options.pan.enablePinch;
-          options.pan.enablePinch = false;
+          var oldTouchZoom = options.zoom.enableTouch;
+          options.zoom.enableTouch = false;
 
           plot = $.plot(placeholder, [
             [
@@ -1057,7 +1015,7 @@ describe("flot touch navigate plugin", function () {
           expect(yaxis.min).toBe(initialYmin);
           expect(yaxis.max).toBe(initialYmax);
 
-          options.pan.enablePinch = oldEnablePinch;
+          options.zoom.enableTouch = oldTouchZoom;
         })
     });
 


### PR DESCRIPTION
This PR contains two changes:

1.  I forgot to apply the `pan.touchMode` option for pinch drag. This PR fix it by using `useSmartPan` tag.

2.  In our use case, we need the touch pan reaction while we do not want any of the pinch reaction of flot. This PR adds an `enablePinch` option to control it.

BTW, I feel it confusing to use `pan.enableTouch` option to control the pinch interaction, since pinching can move (pan) and zoom the plot at the same time. However, in the current design, when panning is enabled by setting `pan.interactive` true and zooming is disabled by setting `zoom.interactive` false, touch-pinching can still zoom the plot if `pan.enableTouch` is true.

I suggest adding an option `zoom.enableTouch` to control whether pinching can zoom the plot. In this case, `pan.enablePinch` should only control whether pinching can pan the plot. Obviously, it has to be a breaking change.