### PR TITLE
Added microsecond support to jquery.flot.time.js

### DIFF
--- a/API.md
+++ b/API.md
@@ -531,14 +531,18 @@ calendars don't follow a simple base 10 system. For many cases, Flot
 abstracts most of this away, but it can still be a bit difficult to
 get the data into Flot. So we'll first discuss the data format.
 
-The time series support in Flot is based on Javascript timestamps,
-i.e. everywhere a time value is expected or handed over, a Javascript
-timestamp number is used. This is a number, not a Date object. A
-Javascript timestamp is the number of milliseconds since January 1,
-1970 00:00:00 UTC. This is almost the same as Unix timestamps, except it's
-in milliseconds, so remember to multiply by 1000!
+The time series support in Flot is based on Epoch timestamps, i.e.,
+everywhere a time value is expected or handed over, a number is used.
+This is a number, not a Date object. Flot supports three different time
+bases in which the timestamps can be given: seconds, milliseconds and
+microseconds. The timestamp is therefore the number of microseconds,
+milliseconds or seconds since January 1, 1970 00:00:00 UTC.
 
-You can see a timestamp like this
+The time base in which the timestamps are given to Flot can be selected
+by setting the "timeBase" option to "microseconds", "milliseconds"
+or "seconds" in axis options. If not set, it defaults to "seconds".
+
+You can see a native Javascript timestamp (in milliseconds) like this
 
 ```js
 alert((new Date()).getTime())
@@ -645,6 +649,7 @@ this:
 ```js
 xaxis: {
     mode: "time",
+    timeBase: "milliseconds",
     timeformat: "%Y/%m/%d"
 }
 ```
@@ -663,6 +668,7 @@ standard strftime specifiers are supported (plus the nonstandard %q):
 %M: minutes, zero-padded (00-59)
 %q: quarter (1-4)
 %S: seconds, zero-padded (00-59)
+%s: sub-seconds, accuracy can be denoted with a number (e.g., %3s)
 %y: year (two digits)
 %Y: year (four digits)
 %p: am/pm
@@ -693,6 +699,12 @@ will use 12 hour AM/PM timestamps instead of 24 hour. This only
 applies if you have not set "timeformat". Use the "%I" and "%p" or
 "%P" options if you want to build your own format string with 12-hour
 times.
+
+If you want to have ticks with a fixed sub-second accuracy, you can add
+a number in the subsecond specifier (e.g., "%3s" for millisecond
+accuracy) in the "timeformat" string". If the accuracy for the sub-second
+timestamps is not given, Flot will automatically determine the accuracy
+depending on the timespan of the axis and the number of ticks, to create.
 
 If the Date object has a strftime property (and it is a function), it
 will be used instead of the built-in formatter. Thus you can include

--- a/source/jquery.flot.time.js
+++ b/source/jquery.flot.time.js
@@ -25,6 +25,67 @@ API.txt for details.
 
     var floorInBase = $.plot.saturated.floorInBase;
 
+    // A mix-in to provide microsecond support to Date like classes.
+    var MicroSecondSupportMixIn = (function(){
+
+        var MixIn = function(Base) {
+            return class extends Base {
+
+                constructor(microEpoch) {
+                    super(microEpoch);
+                    this.microseconds = null;
+                    this.microEpoch = null;
+                    this.update(microEpoch);
+                }
+
+                update(microEpoch) {
+                    super.setTime(microEpoch);
+
+                    // Round epoch to 3 decimal accuracy
+                    microEpoch = Math.round(microEpoch*1000)/1000;
+                    this.microEpoch = microEpoch;
+
+                    // Microseconds are stored as integers
+                    var seconds = microEpoch/1000;
+                    this.microseconds = 1000000 * (seconds - Math.floor(seconds));
+                }
+
+                getTime() {
+                    return this.microEpoch;
+                }
+
+                setTime(microEpoch) {
+                    this.update(microEpoch);
+                }
+
+                getMicroseconds() {
+                    return this.microseconds;
+                };
+
+                setMicroseconds(microseconds) {
+                    // Replace the microsecond part (6 last digits) in microEpoch
+                    var epochWithoutMicroseconds = 1000*Math.floor(this.microEpoch/1000);
+                    var newEpoch = epochWithoutMicroseconds + microseconds/1000;
+                    this.update(newEpoch);
+                };
+
+                setUTCMicroseconds(microseconds) { this.setMicroseconds(microseconds); }
+
+                getUTCMicroseconds() { return this.getMicroseconds(); }
+            };
+        };
+
+        return MixIn;
+    })();
+
+    // Extend Date and timezoneJS.Date (if found) with microsecond support.
+    var MicroDate = class extends MicroSecondSupportMixIn(Date) {};
+    var MicroTimezoneJS;
+
+    if (typeof timezoneJS !== "undefined" && typeof timezoneJS.Date !== "undefined") {
+        MicroTimezoneJS = class extends MicroSecondSupportMixIn(timezoneJS.Date) {}
+    }
+
     // Returns a string with the date d formatted according to fmt.
     // A subset of the Open Group's strftime format is supported.
 
@@ -37,6 +98,18 @@ API.txt for details.
 			n = "" + n;
 			pad = "" + (pad == null ? "0" : pad);
 			return n.length == 1 ? pad + n : n;
+		};
+
+		var formatMicroseconds = function(n, dec) {
+			if (dec < 6 && dec > 0) {
+				var magnitude = Math.pow(10,dec-6);
+				n = Math.round(Math.round(n*magnitude)/magnitude);
+				n = ('00000' + n).slice(-6,-(6 - dec));
+			} else {
+                n = Math.round(n)
+				n = ('00000' + n).slice(-6);
+			}
+			return n;
 		};
 
         var r = [];
@@ -61,10 +134,13 @@ API.txt for details.
 			hours12 = hours;
 		}
 
+        var decimals = -1;
         for (var i = 0; i < fmt.length; ++i) {
 			var c = fmt.charAt(i);
 
-			if (escape) {
+            if (!isNaN(Number(c)) && Number(c) > 0) {
+                decimals = Number(c);
+            } else if (escape) {
 				switch (c) {
 					case 'a': c = "" + dayNames[d.getDay()]; break;
 					case 'b': c = "" + monthNames[d.getMonth()]; break;
@@ -80,6 +156,7 @@ API.txt for details.
 					case 'q':
 						c = "" + (Math.floor(d.getMonth() / 3) + 1); break;
 					case 'S': c = leftPad(d.getSeconds()); break;
+					case 's': c = "" + formatMicroseconds(d.getMicroseconds(),decimals); break;
 					case 'y': c = leftPad(d.getFullYear() % 100); break;
 					case 'Y': c = "" + d.getFullYear(); break;
 					case 'p': c = (isAM) ? ("" + "am") : ("" + "pm"); break;
@@ -124,7 +201,7 @@ API.txt for details.
         addProxyMethod(utc, "getTime", d, "getTime");
         addProxyMethod(utc, "setTime", d, "setTime");
 
-        var props = ["Date", "Day", "FullYear", "Hours", "Milliseconds", "Minutes", "Month", "Seconds"];
+        var props = ["Date", "Day", "FullYear", "Hours", "Minutes", "Month", "Seconds", "Milliseconds", "Microseconds"];
 
         for (var p = 0; p < props.length; p++) {
             addProxyMethod(utc, "get" + props[p], d, "getUTC" + props[p]);
@@ -141,6 +218,8 @@ API.txt for details.
 
         if (opts && opts.timeBase === 'seconds') {
             ts *= 1000;
+        } else if (opts.timeBase === 'microseconds') {
+            ts /= 1000;
         }
 
         if (ts > maxDateValue) {
@@ -150,23 +229,24 @@ API.txt for details.
         }
 
         if (opts.timezone === "browser") {
-            return new Date(ts);
+            return new MicroDate(ts);
         } else if (!opts.timezone || opts.timezone === "utc") {
-            return makeUtcWrapper(new Date(ts));
+            return makeUtcWrapper(new MicroDate(ts));
         } else if (typeof timezoneJS !== "undefined" && typeof timezoneJS.Date !== "undefined") {
-            var d = new timezoneJS.Date();
+            var d = new MicroTimezoneJS(ts);
             // timezone-js is fickle, so be sure to set the time zone before
             // setting the time.
             d.setTimezone(opts.timezone);
             d.setTime(ts);
             return d;
         } else {
-            return makeUtcWrapper(new Date(ts));
+            return makeUtcWrapper(new MicroDate(ts));
         }
     }
 
-    // map of app. size of time units in milliseconds
+    // map of app. size of time units in seconds
     var timeUnitSizeSeconds = {
+        "microsecond": 0.000001,
         "millisecond": 0.001,
         "second": 1,
         "minute": 60,
@@ -177,7 +257,9 @@ API.txt for details.
         "year": 365.2425 * 24 * 60 * 60
     };
 
+    // map of app. size of time units in milliseconds
     var timeUnitSizeMilliseconds = {
+        "microsecond": 0.001,
         "millisecond": 1,
         "second": 1000,
         "minute": 60 * 1000,
@@ -188,10 +270,25 @@ API.txt for details.
         "year": 365.2425 * 24 * 60 * 60 * 1000
     };
 
+    // map of app. size of time units in microseconds
+    var timeUnitSizeMicroseconds = {
+        "microsecond": 1,
+        "millisecond": 1000,
+        "second": 1000000,
+        "minute": 60 * 1000000,
+        "hour": 60 * 60 * 1000000,
+        "day": 24 * 60 * 60 * 1000000,
+        "month": 30 * 24 * 60 * 60 * 1000000,
+        "quarter": 3 * 30 * 24 * 60 * 60 * 1000000,
+        "year": 365.2425 * 24 * 60 * 60 * 1000000
+    };
+
     // the allowed tick sizes, after 1 year we use
     // an integer algorithm
 
     var baseSpec = [
+        [1, "microsecond"], [2, "microsecond"], [5, "microsecond"], [10, "microsecond"],
+        [25, "microsecond"], [50, "microsecond"], [100, "microsecond"], [250, "microsecond"], [500, "microsecond"],
         [1, "millisecond"], [2, "millisecond"], [5, "millisecond"], [10, "millisecond"],
         [25, "millisecond"], [50, "millisecond"], [100, "millisecond"], [250, "millisecond"], [500, "millisecond"],
         [1, "second"], [2, "second"], [5, "second"], [10, "second"],
@@ -227,7 +324,14 @@ API.txt for details.
             (opts.minTickSize && opts.minTickSize[1] ===
             "quarter") ? specQuarters : specMonths;
 
-        var timeUnitSize = opts.timeBase === 'seconds' ? timeUnitSizeSeconds : timeUnitSizeMilliseconds;
+        var timeUnitSize;
+        if (opts.timeBase === 'seconds') {
+            timeUnitSize = timeUnitSizeSeconds;
+        } else if (opts.timeBase === 'milliseconds') {
+            timeUnitSize = timeUnitSizeMilliseconds;
+        } else {
+            timeUnitSize = timeUnitSizeMicroseconds;
+        }
 
         if (opts.minTickSize !== null && opts.minTickSize !== undefined) {
             if (typeof opts.tickSize === "number") {
@@ -284,7 +388,9 @@ API.txt for details.
 
         var step = tickSize * timeUnitSize[unit];
 
-        if (unit === "millisecond") {
+        if (unit === "microsecond") {
+            d.setMicroseconds(floorInBase(d.getMicroseconds(), tickSize));
+        } else if (unit === "millisecond") {
             d.setMilliseconds(floorInBase(d.getMilliseconds(), tickSize));
         } else if (unit === "second") {
             d.setSeconds(floorInBase(d.getSeconds(), tickSize));
@@ -303,10 +409,13 @@ API.txt for details.
 
         // reset smaller components
 
-        if (step >= timeUnitSize.second) {
-            d.setMilliseconds(0);
+        if (step >= timeUnitSize.millisecond) {
+            if (step >= timeUnitSize.second) {
+                d.setMicroseconds(0);
+            } else {
+                d.setMicroseconds(d.getMilliseconds()*1000);
+            }
         }
-
         if (step >= timeUnitSize.minute) {
             d.setSeconds(0);
         }
@@ -338,8 +447,10 @@ API.txt for details.
             v1000 = d.getTime();
             if (opts && opts.timeBase === 'seconds') {
                 v = v1000 / 1000;
-            } else {
+            } else if (opts && opts.timeBase === 'milliseconds') {
                 v = v1000;
+            } else {
+                v = v1000 * 1000;
             }
 
             ticks.push(v);
@@ -367,8 +478,10 @@ API.txt for details.
             } else {
                 if (opts.timeBase === 'seconds') {
                     d.setTime((v + step) * 1000);
-                } else {
+                } else if (opts.timeBase === 'milliseconds') {
                     d.setTime(v + step);
+                } else {
+                    d.setTime((v + step) / 1000);
                 }
             }
         } while (v < axis.max && v !== prev);
@@ -398,15 +511,41 @@ API.txt for details.
 							(axis.options.minTickSize &&
                                 axis.options.minTickSize[1] == "quarter");
 
-                        var timeUnitSize = opts.timeBase === 'seconds' ? timeUnitSizeSeconds : timeUnitSizeMilliseconds;
+                        var timeUnitSize;
+                        if (opts.timeBase === 'seconds') {
+                            timeUnitSize = timeUnitSizeSeconds;
+                        } else if (opts.timeBase === 'milliseconds') {
+                            timeUnitSize = timeUnitSizeMilliseconds;
+                        } else {
+                            timeUnitSize = timeUnitSizeMicroseconds;
+                        }
 
 						var t = axis.tickSize[0] * timeUnitSize[axis.tickSize[1]];
 						var span = axis.max - axis.min;
 						var suffix = (opts.twelveHourClock) ? " %p" : "";
 						var hourCode = (opts.twelveHourClock) ? "%I" : "%H";
+                        var factor;
 						var fmt;
 
-						if (t < timeUnitSize.minute) {
+                        if (opts.timeBase === 'seconds') {
+                            factor = 1;
+                        } else if (opts.timeBase === 'milliseconds') {
+                            factor = 1000;
+                        } else {
+                            factor = 1000000
+                        }
+
+                        if (t < timeUnitSize.second) {
+                            var decimals = -Math.floor(Math.log10(t/factor))
+
+                            // the two-and-halves require an additional decimal
+                            if (String(t).indexOf('25') > -1) {
+                                decimals++;
+                            }
+
+							fmt = "%S.%" + decimals + "s";
+                        } else
+                        if (t < timeUnitSize.minute) {
 							fmt = hourCode + ":%M:%S" + suffix;
 						} else if (t < timeUnitSize.day) {
 							if (span < 2 * timeUnitSize.day) {

--- a/source/jquery.flot.time.js
+++ b/source/jquery.flot.time.js
@@ -16,7 +16,7 @@ API.txt for details.
             timeformat: null, // format string to use
             twelveHourClock: false, // 12 or 24 time in time mode
             monthNames: null, // list of names of months
-            timeBase: 'seconds' // are the values in milliseconds or seconds
+            timeBase: 'seconds' // are the values in given in mircoseconds, milliseconds or seconds
         },
         yaxis: {
             timeBase: 'seconds'
@@ -327,10 +327,10 @@ API.txt for details.
         var timeUnitSize;
         if (opts.timeBase === 'seconds') {
             timeUnitSize = timeUnitSizeSeconds;
-        } else if (opts.timeBase === 'milliseconds') {
-            timeUnitSize = timeUnitSizeMilliseconds;
-        } else {
+        } else if (opts.timeBase === 'microseconds') {
             timeUnitSize = timeUnitSizeMicroseconds;
+        } else {
+            timeUnitSize = timeUnitSizeMilliseconds;
         }
 
         if (opts.minTickSize !== null && opts.minTickSize !== undefined) {
@@ -447,10 +447,10 @@ API.txt for details.
             v1000 = d.getTime();
             if (opts && opts.timeBase === 'seconds') {
                 v = v1000 / 1000;
-            } else if (opts && opts.timeBase === 'milliseconds') {
-                v = v1000;
-            } else {
+            } else if (opts && opts.timeBase === 'microseconds') {
                 v = v1000 * 1000;
+            } else {
+                v = v1000;
             }
 
             ticks.push(v);
@@ -478,10 +478,10 @@ API.txt for details.
             } else {
                 if (opts.timeBase === 'seconds') {
                     d.setTime((v + step) * 1000);
-                } else if (opts.timeBase === 'milliseconds') {
-                    d.setTime(v + step);
-                } else {
+                } else if (opts.timeBase === 'microseconds') {
                     d.setTime((v + step) / 1000);
+                } else {
+                    d.setTime(v + step);
                 }
             }
         } while (v < axis.max && v !== prev);
@@ -514,10 +514,10 @@ API.txt for details.
                         var timeUnitSize;
                         if (opts.timeBase === 'seconds') {
                             timeUnitSize = timeUnitSizeSeconds;
-                        } else if (opts.timeBase === 'milliseconds') {
-                            timeUnitSize = timeUnitSizeMilliseconds;
-                        } else {
+                        } else if (opts.timeBase === 'microseconds') {
                             timeUnitSize = timeUnitSizeMicroseconds;
+                        } else {
+                            timeUnitSize = timeUnitSizeMilliseconds;
                         }
 
 						var t = axis.tickSize[0] * timeUnitSize[axis.tickSize[1]];
@@ -529,10 +529,10 @@ API.txt for details.
 
                         if (opts.timeBase === 'seconds') {
                             factor = 1;
-                        } else if (opts.timeBase === 'milliseconds') {
-                            factor = 1000;
-                        } else {
+                        } else if (opts.timeBase === 'microseconds') {
                             factor = 1000000
+                        } else {
+                            factor = 1000;
                         }
 
                         if (t < timeUnitSize.second) {

--- a/tests/jquery.flot.time.Test.js
+++ b/tests/jquery.flot.time.Test.js
@@ -24,12 +24,13 @@ describe('A Flot chart with absolute time axes', function () {
         return [arr[0], arr[arr.length - 1]];
     };
 
-    var createPlotWithAbsoluteTimeAxis = function (placeholder, data, formatString, base) {
+    var createPlotWithAbsoluteTimeAxis = function (placeholder, data, formatString, base, minTickSize) {
         return $.plot(placeholder, data, {
             xaxis: {
                 mode: 'time',
                 timeformat: formatString,
                 timeBase: base,
+                minTickSize: minTickSize,
                 showTickLabels: 'all'
             },
             yaxis: {}
@@ -81,20 +82,47 @@ describe('A Flot chart with absolute time axes', function () {
         it('formats ticks to microsecond accuracy', function () {
             plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0, 1], [1000125, 2]]], '%H:%M:%S.%s', 'microseconds');
 
-            expect(validateTickLabelFormat(plot.getAxes().xaxis.ticks), /00:00:0\d\.\d{6}/).toEqual(true);
+            expect(validateTickLabelFormat(plot.getAxes().xaxis.ticks, /00:00:0\d\.\d{6}/)).toEqual(true);
             expect(firstAndLast(plot.getAxes().xaxis.ticks)).toEqual([
                 {v: 0, label: '00:00:00.000000'},
                 {v: 1000125, label: '00:00:01.000125'}
             ]);
         });
-        it('supports tick formatted to millisecond (3 decimals) accuracy', function () {
+        it('formats ticks to millisecond (3 decimals) accuracy', function () {
             plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0, 1], [1002000, 2]]], '%H:%M:%S.%3s', 'microseconds');
 
-            expect(validateTickLabelFormat(plot.getAxes().xaxis.ticks), /00:00:0\d\.\d{3}/).toEqual(true);
+            expect(validateTickLabelFormat(plot.getAxes().xaxis.ticks, /00:00:0\d\.\d{3}/)).toEqual(true);
             expect(firstAndLast(plot.getAxes().xaxis.ticks)).toEqual([
                 {v: 0, label: '00:00:00.000'},
                 {v: 1002000, label: '00:00:01.002'}
             ]);
+        });
+        it('creates ticks automatically to microsecond accuracy', function () {
+            plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0, 1], [10, 2]]], null, 'microseconds');
+
+            expect(validateTickLabelFormat(plot.getAxes().xaxis.ticks, /00\.\d{6}/)).toEqual(true);
+            expect(firstAndLast(plot.getAxes().xaxis.ticks)).toEqual([
+                {v: 0, label: '00.000000'},
+                {v: 10, label: '00.000010'}
+            ]);
+        });
+        it('creates quarter-second timestaps', function () {
+            plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0, 1], [1, 2]]], null, 'seconds', [250, 'millisecond']);
+
+            expect(validateTickLabelFormat(plot.getAxes().xaxis.ticks, /0\d\.(00|25|50|75)/)).toEqual(true);
+            expect(firstAndLast(plot.getAxes().xaxis.ticks)).toEqual([
+                {v: 0, label: '00.00'},
+                {v: 1, label: '01.00'}
+            ])
+        });
+        it('creates quarter-millisecond timestaps', function () {
+            plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0, 1], [1, 2]]], null, 'milliseconds', [250, 'microsecond']);
+
+            expect(validateTickLabelFormat(plot.getAxes().xaxis.ticks, /00\.00\d(00|25|50|75)/)).toEqual(true);
+            expect(firstAndLast(plot.getAxes().xaxis.ticks)).toEqual([
+                {v: 0, label: '00.00000'},
+                {v: 1, label: '00.00100'}
+            ])
         });
     });
 });

--- a/tests/jquery.flot.time.Test.js
+++ b/tests/jquery.flot.time.Test.js
@@ -24,20 +24,30 @@ describe('A Flot chart with absolute time axes', function () {
         return [arr[0], arr[arr.length - 1]];
     };
 
-    var createPlotWithAbsoluteTimeAxis = function (placeholder, data, formatString) {
+    var createPlotWithAbsoluteTimeAxis = function (placeholder, data, formatString, base) {
         return $.plot(placeholder, data, {
             xaxis: {
                 mode: 'time',
                 timeformat: formatString,
-                timeBase: 'millseconds',
+                timeBase: base,
                 showTickLabels: 'all'
             },
             yaxis: {}
         });
     };
 
+    var validateTickLabelFormat = function (ticks, regexFormat) {
+        var isFormatCorrect = true;
+        ticks.forEach(function (t) {
+            if (!t.label.match(regexFormat)) {
+                isFormatCorrect = false;
+            }
+        });
+        return isFormatCorrect;
+    };
+
     it('shows time ticks', function () {
-        plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0, 1], [1000, 2]]], '%Y/%m/%d %M:%S');
+        plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0, 1], [1000, 2]]], '%Y/%m/%d %M:%S', 'milliseconds');
 
         expect(firstAndLast(plot.getAxes().xaxis.ticks)).toEqual([
             {v: 0, label: '1970/01/01 00:00'},
@@ -53,6 +63,38 @@ describe('A Flot chart with absolute time axes', function () {
             expect(dateGenerator(8640000000000002, {}).date).toEqual(new Date(8640000000000000));
             expect(dateGenerator(-8640000000000001, {}).date).toEqual(new Date(-8640000000000000));
             expect(dateGenerator(-9640000000000000, {}).date).toEqual(new Date(-8640000000000000));
+        });
+    });
+
+    describe('timebase in microseconds', function () {
+        it('supports timestamps given in microseconds', function () {
+            plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0, 1], [1000000, 2]]], '%Y/%m/%d %M:%S', 'microseconds');
+
+            expect(firstAndLast(plot.getAxes().xaxis.ticks)).toEqual([
+                {v: 0, label: '1970/01/01 00:00'},
+                {v: 1000000, label: '1970/01/01 00:01'}
+            ]);
+        });
+    });
+
+    describe('sub-second ticks', function () {
+        it('formats ticks to microsecond accuracy', function () {
+            plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0, 1], [1000125, 2]]], '%H:%M:%S.%s', 'microseconds');
+
+            expect(validateTickLabelFormat(plot.getAxes().xaxis.ticks), /00:00:0\d\.\d{6}/).toEqual(true);
+            expect(firstAndLast(plot.getAxes().xaxis.ticks)).toEqual([
+                {v: 0, label: '00:00:00.000000'},
+                {v: 1000125, label: '00:00:01.000125'}
+            ]);
+        });
+        it('supports tick formatted to millisecond (3 decimals) accuracy', function () {
+            plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0, 1], [1002000, 2]]], '%H:%M:%S.%3s', 'microseconds');
+
+            expect(validateTickLabelFormat(plot.getAxes().xaxis.ticks), /00:00:0\d\.\d{3}/).toEqual(true);
+            expect(firstAndLast(plot.getAxes().xaxis.ticks)).toEqual([
+                {v: 0, label: '00:00:00.000'},
+                {v: 1002000, label: '00:00:01.002'}
+            ]);
         });
     });
 });

--- a/tests/jquery.flot.time.Test.js
+++ b/tests/jquery.flot.time.Test.js
@@ -106,7 +106,7 @@ describe('A Flot chart with absolute time axes', function () {
                 {v: 10, label: '00.000010'}
             ]);
         });
-        it('creates quarter-second timestaps', function () {
+        it('creates quarter-second ticks', function () {
             plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0, 1], [1, 2]]], null, 'seconds', [250, 'millisecond']);
 
             expect(validateTickLabelFormat(plot.getAxes().xaxis.ticks, /0\d\.(00|25|50|75)/)).toEqual(true);
@@ -115,7 +115,7 @@ describe('A Flot chart with absolute time axes', function () {
                 {v: 1, label: '01.00'}
             ])
         });
-        it('creates quarter-millisecond timestaps', function () {
+        it('creates quarter-millisecond ticks', function () {
             plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0, 1], [1, 2]]], null, 'milliseconds', [250, 'microsecond']);
 
             expect(validateTickLabelFormat(plot.getAxes().xaxis.ticks, /00\.00\d(00|25|50|75)/)).toEqual(true);


### PR DESCRIPTION
Added:

- an option to set timeBase as microseconds

- an option to show ticks in sub-second accuracy (millisecond, microsecond)

- timeformat option %s = microseconds, %Ns, in which N is a number denoting accuracy

For example, format string 
- "%H:%M:%S.%s"  would format timestamp 1000500 (microseconds) as "00:00:01.000500"
- "%H:%M:%S.%2s" would format timestamp 1020000 (microseconds) as "00:00:01.02"