### PR TITLE
Allow touch event bubble

### DIFF
--- a/docs/navigate.md
+++ b/docs/navigate.md
@@ -26,6 +26,8 @@ The plugin supports these options:
         touchMode: ""
     }
 
+    propagateOriginTouch: false
+
     xaxis: {
         axisZoom: true, //zoom axis when mouse over it is allowed
         plotZoom: true, //zoom axis is allowed for plot zoom
@@ -72,6 +74,8 @@ and double tap (to recenter).
 
 **touchMode** a string specifies the pan mode of touch pan.
 The accepted values is the sams as **mode** option. Default: 'manual'
+
+**propagateOriginTouch** set true to allow the propagation of origin touch events (e.g. 'touchstart') that is already handled for pan or pinch.
 
 Example API usage:
 ```js

--- a/source/jquery.flot.touch.js
+++ b/source/jquery.flot.touch.js
@@ -277,7 +277,7 @@
         function preventEventDefault(e) {
             if (!gestureState.isUnsupportedGesture) {
                 e.preventDefault();
-                if (!options.touch.propagateOriginEvent) {
+                if (!plot.getOptions().propagateOriginTouch) {
                     e.stopPropagation();
                 }
             }

--- a/source/jquery.flot.touch.js
+++ b/source/jquery.flot.touch.js
@@ -8,9 +8,7 @@
         pan: {
             enableTouch: false
         },
-        touch: {
-            propagateOriginEvent: false
-        },
+        propagateOriginTouch: false
     };
 
     function init(plot) {

--- a/source/jquery.flot.touch.js
+++ b/source/jquery.flot.touch.js
@@ -22,7 +22,7 @@
                 prevTap: { x: 0, y: 0 },
                 currentTap: { x: 0, y: 0 },
                 interceptedLongTap: false,
-                allowEventPropagation: false,
+                isMultipleTouch: false,
                 prevTapTime: null,
                 tapStartTime: null,
                 longTapTriggerId: null
@@ -112,7 +112,7 @@
                 updateCurrentForDoubleTap(e);
                 updateStateForLongTapEnd(e);
 
-                if (!gestureState.allowEventPropagation) {
+                if (!gestureState.isMultipleTouch) {
                     mainEventHolder.dispatchEvent(new CustomEvent('pandrag', { detail: e }));
                 }
             },
@@ -137,7 +137,7 @@
             touchmove: function(e) {
                 preventEventPropagation(e);
                 gestureState.twoTouches = isPinchEvent(e);
-                if (!gestureState.allowEventPropagation) {
+                if (!gestureState.isMultipleTouch) {
                     mainEventHolder.dispatchEvent(new CustomEvent('pinchdrag', { detail: e }));
                 }
             },
@@ -276,9 +276,8 @@
         }
 
         function preventEventPropagation(e) {
-            if (!gestureState.allowEventPropagation) {
+            if (!gestureState.isMultipleTouch) {
                 e.preventDefault();
-                e.stopPropagation();
             }
         }
 
@@ -296,9 +295,9 @@
 
         function updateOnMultipleTouches(e) {
             if (e.touches.length >= 3) {
-                gestureState.allowEventPropagation = true;
+                gestureState.isMultipleTouch = true;
             } else {
-                gestureState.allowEventPropagation = false;
+                gestureState.isMultipleTouch = false;
             }
         }
 

--- a/source/jquery.flot.touch.js
+++ b/source/jquery.flot.touch.js
@@ -75,8 +75,6 @@
                 case 'tap':
                     tap[e.type](e);
                     break;
-                default:
-                    break;
             }
         }
 

--- a/source/jquery.flot.touch.js
+++ b/source/jquery.flot.touch.js
@@ -22,7 +22,7 @@
                 prevTap: { x: 0, y: 0 },
                 currentTap: { x: 0, y: 0 },
                 interceptedLongTap: false,
-                isMultipleTouch: false,
+                isMultipleTouches: false,
                 prevTapTime: null,
                 tapStartTime: null,
                 longTapTriggerId: null
@@ -107,18 +107,18 @@
             },
 
             touchmove: function(e) {
-                preventEventPropagation(e);
+                preventNonMultipleTouchesDefault(e);
 
                 updateCurrentForDoubleTap(e);
                 updateStateForLongTapEnd(e);
 
-                if (!gestureState.isMultipleTouch) {
+                if (!gestureState.isMultipleTouches) {
                     mainEventHolder.dispatchEvent(new CustomEvent('pandrag', { detail: e }));
                 }
             },
 
             touchend: function(e) {
-                preventEventPropagation(e);
+                preventNonMultipleTouchesDefault(e);
 
                 if (wasPinchEvent(e)) {
                     mainEventHolder.dispatchEvent(new CustomEvent('pinchend', { detail: e }));
@@ -135,21 +135,21 @@
             },
 
             touchmove: function(e) {
-                preventEventPropagation(e);
+                preventNonMultipleTouchesDefault(e);
                 gestureState.twoTouches = isPinchEvent(e);
-                if (!gestureState.isMultipleTouch) {
+                if (!gestureState.isMultipleTouches) {
                     mainEventHolder.dispatchEvent(new CustomEvent('pinchdrag', { detail: e }));
                 }
             },
 
             touchend: function(e) {
-                preventEventPropagation(e);
+                preventNonMultipleTouchesDefault(e);
             }
         };
 
         var doubleTap = {
             onDoubleTap: function(e) {
-                preventEventPropagation(e);
+                preventNonMultipleTouchesDefault(e);
                 mainEventHolder.dispatchEvent(new CustomEvent('doubletap', { detail: e }));
             }
         };
@@ -205,7 +205,7 @@
             touchend: function(e) {
                 if (tap.isTap(e)) {
                     mainEventHolder.dispatchEvent(new CustomEvent('tap', { detail: e }));
-                    preventEventPropagation(e);
+                    preventNonMultipleTouchesDefault(e);
                 }
             },
 
@@ -275,8 +275,8 @@
             return false;
         }
 
-        function preventEventPropagation(e) {
-            if (!gestureState.isMultipleTouch) {
+        function preventNonMultipleTouchesDefault(e) {
+            if (!gestureState.isMultipleTouches) {
                 e.preventDefault();
             }
         }
@@ -295,9 +295,9 @@
 
         function updateOnMultipleTouches(e) {
             if (e.touches.length >= 3) {
-                gestureState.isMultipleTouch = true;
+                gestureState.isMultipleTouches = true;
             } else {
-                gestureState.isMultipleTouch = false;
+                gestureState.isMultipleTouches = false;
             }
         }
 

--- a/source/jquery.flot.touch.js
+++ b/source/jquery.flot.touch.js
@@ -7,7 +7,10 @@
     var options = {
         pan: {
             enableTouch: false
-        }
+        },
+        touch: {
+            propagateOriginEvent: false
+        },
     };
 
     function init(plot) {
@@ -22,7 +25,7 @@
                 prevTap: { x: 0, y: 0 },
                 currentTap: { x: 0, y: 0 },
                 interceptedLongTap: false,
-                isMultipleTouches: false,
+                isUnsupportedGesture: false,
                 prevTapTime: null,
                 tapStartTime: null,
                 longTapTriggerId: null
@@ -105,18 +108,18 @@
             },
 
             touchmove: function(e) {
-                preventNonMultipleTouchesDefault(e);
+                preventEventDefault(e);
 
                 updateCurrentForDoubleTap(e);
                 updateStateForLongTapEnd(e);
 
-                if (!gestureState.isMultipleTouches) {
+                if (!gestureState.isUnsupportedGesture) {
                     mainEventHolder.dispatchEvent(new CustomEvent('pandrag', { detail: e }));
                 }
             },
 
             touchend: function(e) {
-                preventNonMultipleTouchesDefault(e);
+                preventEventDefault(e);
 
                 if (wasPinchEvent(e)) {
                     mainEventHolder.dispatchEvent(new CustomEvent('pinchend', { detail: e }));
@@ -133,21 +136,21 @@
             },
 
             touchmove: function(e) {
-                preventNonMultipleTouchesDefault(e);
+                preventEventDefault(e);
                 gestureState.twoTouches = isPinchEvent(e);
-                if (!gestureState.isMultipleTouches) {
+                if (!gestureState.isUnsupportedGesture) {
                     mainEventHolder.dispatchEvent(new CustomEvent('pinchdrag', { detail: e }));
                 }
             },
 
             touchend: function(e) {
-                preventNonMultipleTouchesDefault(e);
+                preventEventDefault(e);
             }
         };
 
         var doubleTap = {
             onDoubleTap: function(e) {
-                preventNonMultipleTouchesDefault(e);
+                preventEventDefault(e);
                 mainEventHolder.dispatchEvent(new CustomEvent('doubletap', { detail: e }));
             }
         };
@@ -203,7 +206,7 @@
             touchend: function(e) {
                 if (tap.isTap(e)) {
                     mainEventHolder.dispatchEvent(new CustomEvent('tap', { detail: e }));
-                    preventNonMultipleTouchesDefault(e);
+                    preventEventDefault(e);
                 }
             },
 
@@ -273,9 +276,12 @@
             return false;
         }
 
-        function preventNonMultipleTouchesDefault(e) {
-            if (!gestureState.isMultipleTouches) {
+        function preventEventDefault(e) {
+            if (!gestureState.isUnsupportedGesture) {
                 e.preventDefault();
+                if (!options.touch.propagateOriginEvent) {
+                    e.stopPropagation();
+                }
             }
         }
 
@@ -293,9 +299,9 @@
 
         function updateOnMultipleTouches(e) {
             if (e.touches.length >= 3) {
-                gestureState.isMultipleTouches = true;
+                gestureState.isUnsupportedGesture = true;
             } else {
-                gestureState.isMultipleTouches = false;
+                gestureState.isUnsupportedGesture = false;
             }
         }
 

--- a/tests/jquery.flot.touch.Test.js
+++ b/tests/jquery.flot.touch.Test.js
@@ -28,33 +28,6 @@ describe("flot touch plugin", function () {
         expect(spy).toHaveBeenCalledWith('touchend', jasmine.any(Function));
     });
 
-    it('do not stop origin touch event propagation if it is allowed', () => {
-        jasmine.clock().install().mockDate();
-        
-        var oldPropagateOriginTouch = options.propagateOriginTouch ;
-        options.propagateOriginTouch = true;
-
-        plot = $.plot(placeholder, [[]], options);
-        var eventHolder = plot.getEventHolder(),
-            spy = jasmine.createSpy('origin touch event handler');
-
-        eventHolder.parentNode.addEventListener('touchstart', spy, { once: true });
-        eventHolder.parentNode.addEventListener('touchmove', spy, { once: true });
-        eventHolder.parentNode.addEventListener('touchend', spy, { once: true });
-
-        eventHolder.dispatchEvent(new TouchEvent('touchstart', { bubbles: true, touches: [new Touch({ identifier: 0, target: eventHolder })] }));
-        jasmine.clock().tick(100);
-        eventHolder.dispatchEvent(new TouchEvent('touchmove', { bubbles: true, touches: [new Touch({ identifier: 0, target: eventHolder })] }));
-        jasmine.clock().tick(100);
-        eventHolder.dispatchEvent(new TouchEvent('touchend', { bubbles: true, touches: [new Touch({ identifier: 0, target: eventHolder })] }));
-        jasmine.clock().tick(100);
-
-        expect(spy).toHaveBeenCalledTimes(3);
-
-        options.propagateOriginTouch = oldPropagateOriginTouch;
-        jasmine.clock().uninstall();
-    });
-
     describe('long tap', function() {
 
         beforeEach(function() {

--- a/tests/jquery.flot.touch.Test.js
+++ b/tests/jquery.flot.touch.Test.js
@@ -31,28 +31,27 @@ describe("flot touch plugin", function () {
     it('do not stop origin touch event propagation if it is allowed', () => {
         jasmine.clock().install().mockDate();
         
-        var oldPropagateOriginEvent = options.propagateOriginTouch ;
-        options.propagateOriginTouch = false;
+        var oldPropagateOriginTouch = options.propagateOriginTouch ;
+        options.propagateOriginTouch = true;
 
         plot = $.plot(placeholder, [[]], options);
         var eventHolder = plot.getEventHolder(),
-            spy = jasmine.createSpy('origin touch event handler'),
-            coords = [{x: 10, y: 20}];
+            spy = jasmine.createSpy('origin touch event handler');
 
-        placeholder[0].addEventListener('touchstart', spy, { once: true });
-        placeholder[0].addEventListener('touchmove', spy, { once: true });
-        placeholder[0].addEventListener('touchend', spy, { once: true });
-        
-        simulate.sendTouchEvents(coords, eventHolder, 'touchstart');
+        eventHolder.parentNode.addEventListener('touchstart', spy, { once: true });
+        eventHolder.parentNode.addEventListener('touchmove', spy, { once: true });
+        eventHolder.parentNode.addEventListener('touchend', spy, { once: true });
+
+        eventHolder.dispatchEvent(new TouchEvent('touchstart', { bubbles: true, touches: [new Touch({ identifier: 0, target: eventHolder })] }));
         jasmine.clock().tick(100);
-        simulate.sendTouchEvents(coords, eventHolder, 'touchmove');
+        eventHolder.dispatchEvent(new TouchEvent('touchmove', { bubbles: true, touches: [new Touch({ identifier: 0, target: eventHolder })] }));
         jasmine.clock().tick(100);
-        simulate.sendTouchEvents(coords, eventHolder, 'touchend');
+        eventHolder.dispatchEvent(new TouchEvent('touchend', { bubbles: true, touches: [new Touch({ identifier: 0, target: eventHolder })] }));
         jasmine.clock().tick(100);
 
         expect(spy).toHaveBeenCalledTimes(3);
 
-        options.propagateOriginTouch = oldPropagateOriginEvent;
+        options.propagateOriginTouch = oldPropagateOriginTouch;
         jasmine.clock().uninstall();
     });
 

--- a/tests/jquery.flot.touch.Test.js
+++ b/tests/jquery.flot.touch.Test.js
@@ -28,6 +28,33 @@ describe("flot touch plugin", function () {
         expect(spy).toHaveBeenCalledWith('touchend', jasmine.any(Function));
     });
 
+    it('do not interpret gestures when user interaction is not active', () => {
+        jasmine.clock().install().mockDate();
+        
+        var oldZoomActive = options.zoom.active,
+            oldPanActive = options.pan.active;
+        options.zoom.active = false;
+        options.pan.active = false;
+
+        plot = $.plot(placeholder, [[]], options);
+        var eventHolder = plot.getEventHolder(),
+            spy = jasmine.createSpy('interpreted touch event handler'),
+            coords = [{x: 10, y: 20}];
+        
+        simulate.sendTouchEvents(coords, eventHolder, 'touchstart');
+        jasmine.clock().tick(100);
+        simulate.sendTouchEvents(coords, eventHolder, 'touchmove');
+        jasmine.clock().tick(100);
+        simulate.sendTouchEvents(coords, eventHolder, 'touchend');
+        jasmine.clock().tick(100);
+
+        expect(spy).not.toHaveBeenCalled();
+
+        options.zoom.active = oldZoomActive;
+        options.pan.active = oldPanActive;
+        jasmine.clock().uninstall();
+    });
+
     describe('long tap', function() {
 
         beforeEach(function() {

--- a/tests/jquery.flot.touch.Test.js
+++ b/tests/jquery.flot.touch.Test.js
@@ -31,8 +31,8 @@ describe("flot touch plugin", function () {
     it('do not stop origin touch event propagation if it is allowed', () => {
         jasmine.clock().install().mockDate();
         
-        var oldPropagateOriginEvent = options.touch.propagateOriginEvent;
-        options.touch.propagateOriginEvent = false;
+        var oldPropagateOriginEvent = options.propagateOriginTouch ;
+        options.propagateOriginTouch = false;
 
         plot = $.plot(placeholder, [[]], options);
         var eventHolder = plot.getEventHolder(),
@@ -52,7 +52,7 @@ describe("flot touch plugin", function () {
 
         expect(spy).toHaveBeenCalledTimes(3);
 
-        options.touch.propagateOriginEvent = oldPropagateOriginEvent;
+        options.propagateOriginTouch = oldPropagateOriginEvent;
         jasmine.clock().uninstall();
     });
 

--- a/tests/jquery.flot.touch.Test.js
+++ b/tests/jquery.flot.touch.Test.js
@@ -39,9 +39,9 @@ describe("flot touch plugin", function () {
             spy = jasmine.createSpy('origin touch event handler'),
             coords = [{x: 10, y: 20}];
 
-        placeholder.addEventListener('touchstart', spy, { once: true });
-        placeholder.addEventListener('touchmove', spy, { once: true });
-        placeholder.addEventListener('touchend', spy, { once: true });
+        placeholder[0].addEventListener('touchstart', spy, { once: true });
+        placeholder[0].addEventListener('touchmove', spy, { once: true });
+        placeholder[0].addEventListener('touchend', spy, { once: true });
         
         simulate.sendTouchEvents(coords, eventHolder, 'touchstart');
         jasmine.clock().tick(100);

--- a/tests/jquery.flot.touch.Test.js
+++ b/tests/jquery.flot.touch.Test.js
@@ -28,18 +28,20 @@ describe("flot touch plugin", function () {
         expect(spy).toHaveBeenCalledWith('touchend', jasmine.any(Function));
     });
 
-    it('do not interpret gestures when user interaction is not active', () => {
+    it('do not stop origin touch event propagation if it is allowed', () => {
         jasmine.clock().install().mockDate();
         
-        var oldZoomActive = options.zoom.active,
-            oldPanActive = options.pan.active;
-        options.zoom.active = false;
-        options.pan.active = false;
+        var oldPropagateOriginEvent = options.touch.propagateOriginEvent;
+        options.touch.propagateOriginEvent = false;
 
         plot = $.plot(placeholder, [[]], options);
         var eventHolder = plot.getEventHolder(),
-            spy = jasmine.createSpy('interpreted touch event handler'),
+            spy = jasmine.createSpy('origin touch event handler'),
             coords = [{x: 10, y: 20}];
+
+        placeholder.addEventListener('touchstart', spy, { once: true });
+        placeholder.addEventListener('touchmove', spy, { once: true });
+        placeholder.addEventListener('touchend', spy, { once: true });
         
         simulate.sendTouchEvents(coords, eventHolder, 'touchstart');
         jasmine.clock().tick(100);
@@ -48,10 +50,9 @@ describe("flot touch plugin", function () {
         simulate.sendTouchEvents(coords, eventHolder, 'touchend');
         jasmine.clock().tick(100);
 
-        expect(spy).not.toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledTimes(3);
 
-        options.zoom.active = oldZoomActive;
-        options.pan.active = oldPanActive;
+        options.touch.propagateOriginEvent = oldPropagateOriginEvent;
         jasmine.clock().uninstall();
     });
 


### PR DESCRIPTION
We are designing some touch interaction on the graph, which is not supposed to be into flot since it is highly customized for one specific use case. However, I noticed there are almost no native touch event bubbles out from flot so the listeners I added to the container of flot are not working at all.

This PR removes the `stopPropagation` calls inside flot touch plugin to allow the native touch events, `touchstart`, `touchmove`, and `touchend`, to bubble out.

I understand the necessity of preventing the events' default behavior, which is page moving or resizing. But I do not figure out any reason to stop propagation of the events? If there is not any specific reason, do you agree to allow these event propagation? @atmgrifter00 