### PR TITLE
fix legend label issue

### DIFF
--- a/source/jquery.flot.legend.js
+++ b/source/jquery.flot.legend.js
@@ -278,17 +278,22 @@
     // Generate a list of legend entries in their final order
     function getLegendEntries(series, labelFormatter, sorted) {
         var lf = labelFormatter,
-            legendEntries = series.map(function(s, i) {
-                return {
-                    label: (lf ? lf(s.label, s) : s.label) || 'Plot ' + (i + 1),
-                    color: s.color,
-                    options: {
-                        lines: s.lines,
-                        points: s.points,
-                        bars: s.bars
+            legendEntries = series.reduce(function(validEntries, s, i) {
+                var labelEval = (lf ? lf(s.label, s) : s.label)
+                if (s.hasOwnProperty("label") ? labelEval : true) {
+                    var entry = {
+                        label: labelEval || 'Plot ' + (i + 1),
+                        color: s.color,
+                        options: {
+                            lines: s.lines,
+                            points: s.points,
+                            bars: s.bars
+                        }
                     }
-                };
-            });
+                    validEntries.push(entry)
+                }
+                return validEntries;
+            }, []);
 
         // Sort the legend using either the default or a custom comparator
         if (sorted) {


### PR DESCRIPTION
Use `.reduce()` instead of `.map() ` to filter for any series that a user has chosen to exclude from the legend. We must first check to see if the series object has a `label` property, which is done in the ternary operator embedded in the `if` statement on line 283. If it does, the ternary `labelEval` checks for any labelFormatter, and also checks for a falsy `null` value set by the user. If the `label` property doesn't exist, we add a legend entry by default, using the generic `'Plot ' + (i + 1)`