### PR TITLE
Explicity perform null check on bar hover index

### DIFF
--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -2495,7 +2495,7 @@ Licensed under the MIT license.
 
                 if (s.bars.show && !item) { // no other point can be nearby
                     var foundIndex = findNearbyBar(s, mouseX, mouseY);
-                    if (foundIndex) item = [i, foundIndex];
+                    if (foundIndex !== null) item = [i, foundIndex];
                 }
             }
 


### PR DESCRIPTION
An index of 0 is falsey and fails this check