### PR TITLE
Also trigger 'drawingdone' event to the place holder

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1193,11 +1193,14 @@ can call:
     redraws (e.g. from a mousemove). You can get to the overlay by
     setting up a drawOverlay hook.
     This function will also trigger the dispatching of the
-    'onDrawingDone' custom event, which can be used to notify listeners
-    (drawOverlay hooks) about the finishing of a drawing operation.
+    'onDrawingDone' custom event on the eventholder, and "drawingdown"
+    event on the placeholder, which can be used to notify listeners
+    about the finishing of a drawing operation (drawOverlay hooks).
     Use addEventListener('onDrawingDone', callback) and
-    removeEventListener('onDrawingDone', callback), to register and unregister
-    handlers for 'onDrawingDone' event.
+    removeEventListener('onDrawingDone', callback), to register and
+    unregister handlers for 'onDrawingDone' event, or use
+    on('drawingdone', callback) and off('drawingdone', callback)
+    to register and unregister handlers for 'drawingdone' event.
 
  - width()/height()
 
@@ -1648,11 +1651,15 @@ hooks in the plugins bundled with Flot.
     metrics computed by Flot, e.g. plot.width()/plot.height(). See the
     crosshair plugin for an example.
 
-    This hook dispatches the 'onDrawingDone' custom event.
-    It notifies listeners about the finishing of a drawing operation.
-    Use addEventListener('onDrawingDone', callback) and
-    removeEventListener('onDrawingDone', callback), to register and unregister
-    handlers for 'onDrawingDone' event.
+    After this hook excuted, the dispatching of the 'onDrawingDone'
+    custom event on the eventholder will be triggered, as well as the
+    "drawingdown" event will be fired on the placeholder, which can
+    be used to notify listeners about the finishing of a drawing
+    operation. Use addEventListener('onDrawingDone', callback) and
+    removeEventListener('onDrawingDone', callback), to register and
+    unregister handlers for 'onDrawingDone' event, or use
+    on('drawingdone', callback) and off('drawingdone', callback)
+    to register and unregister handlers for 'drawingdone' event.
 
  - resize   [phase 7]
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1193,14 +1193,15 @@ can call:
     redraws (e.g. from a mousemove). You can get to the overlay by
     setting up a drawOverlay hook.
     This function will also trigger the dispatching of the
-    'onDrawingDone' custom event on the eventholder, and "drawingdown"
+    'onDrawingDone' custom event on the eventholder, and 'drawingdone'
     event on the placeholder, which can be used to notify listeners
     about the finishing of a drawing operation (drawOverlay hooks).
     Use addEventListener('onDrawingDone', callback) and
-    removeEventListener('onDrawingDone', callback), to register and
+    removeEventListener('onDrawingDone', callback) to register and
     unregister handlers for 'onDrawingDone' event, or use
-    on('drawingdone', callback) and off('drawingdone', callback)
-    to register and unregister handlers for 'drawingdone' event.
+    $('#placeholder').bind('drawingdone', callback) and
+    $('#placeholder').unbind('drawingdone', callback) to 
+    register and unregister handlers for 'drawingdone' event.
 
  - width()/height()
 
@@ -1651,15 +1652,16 @@ hooks in the plugins bundled with Flot.
     metrics computed by Flot, e.g. plot.width()/plot.height(). See the
     crosshair plugin for an example.
 
-    After this hook excuted, the dispatching of the 'onDrawingDone'
+    After this hook executes, the dispatching of the 'onDrawingDone'
     custom event on the eventholder will be triggered, as well as the
-    "drawingdown" event will be fired on the placeholder, which can
+    'drawingdone' event will be fired on the placeholder, which can
     be used to notify listeners about the finishing of a drawing
     operation. Use addEventListener('onDrawingDone', callback) and
-    removeEventListener('onDrawingDone', callback), to register and
+    removeEventListener('onDrawingDone', callback) to register and
     unregister handlers for 'onDrawingDone' event, or use
-    on('drawingdone', callback) and off('drawingdone', callback)
-    to register and unregister handlers for 'drawingdone' event.
+    $('#placeholder').bind('drawingdone', callback) and
+    $('#placeholder').unbind('drawingdone', callback) to
+    register and unregister handlers for 'drawingdone' event.
 
  - resize   [phase 7]
 

--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -2709,7 +2709,7 @@ Licensed under the MIT license.
             executeHooks(hooks.drawOverlay, [octx, overlay]);
             var event = new CustomEvent('onDrawingDone');
             plot.getEventHolder().dispatchEvent(event);
-            plot.getPlaceholder().trigger('onDrawingDone');
+            plot.getPlaceholder().trigger('drawingdone');
         }
 
         function getColorOrGradient(spec, bottom, top, defaultColor) {

--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -2709,6 +2709,7 @@ Licensed under the MIT license.
             executeHooks(hooks.drawOverlay, [octx, overlay]);
             var event = new CustomEvent('onDrawingDone');
             plot.getEventHolder().dispatchEvent(event);
+            plot.getPlaceholder().trigger('onDrawingDone');
         }
 
         function getColorOrGradient(spec, bottom, top, defaultColor) {


### PR DESCRIPTION
Drawing done is a very useful timing while the user needs some custom side effects, as important as, even more important than, `plotpan` and `plotzoom`. However, flot only triggers the `onDrawingDone`  event on the **event holder**, whose event listener would be clean-up each time the plot is re-created. Is make this event hard to use, since one has to register the listener every time re-create plot. In addition, this event behaves differently than `plotpan` and `plotzoom`. (`plotpan` and `plotzoom` is triggered on place holder instead of event holder)

The PR adds a new event `drawingdone` that is trigger on the place holder. It follows the way of `plotpan` and `plotzoom`. The old event `onDrawingDone` is not changed to prevent breaking.
