### PR TITLE
Use Number coercion to fix the issue that Math.pow() may lose precision

### DIFF
--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -46,7 +46,7 @@ Licensed under the MIT license.
             axis.tickDecimals = precision;
         }
 
-        var factor = axis.tickDecimals ? Math.pow(10, axis.tickDecimals) : 1,
+        var factor = axis.tickDecimals ? parseFloat('1e' + axis.tickDecimals) : 1,
             formatted = "" + Math.round(value * factor) / factor;
 
         // If tickDecimals was specified, ensure that we have exactly that
@@ -68,7 +68,7 @@ Licensed under the MIT license.
         var expPosition = ("" + value).indexOf("e"),
             exponentValue = parseInt(("" + value).substr(expPosition + 1)),
             tenExponent = expPosition !== -1 ? exponentValue : (value > 0 ? Math.floor(Math.log(value) / Math.LN10) : 0),
-            roundWith = Math.pow(10, tenExponent),
+            roundWith = parseFloat('1e' + tenExponent),
             x = value / roundWith;
 
         if (precision) {
@@ -1517,7 +1517,7 @@ Licensed under the MIT license.
                 dec = tickDecimals;
             }
 
-            var magn = Math.pow(10, -dec),
+            var magn = parseFloat('1e-' + dec),
                 norm = delta / magn;
 
             if (norm > 2.25 && norm < 3 && (dec + 1) <= tickDecimals) {
@@ -1537,7 +1537,7 @@ Licensed under the MIT license.
                 dec = tickDecimals;
             }
 
-            var magn = Math.pow(10, -dec),
+            var magn = parseFloat('1e-' + dec),
                 norm = delta / magn, // norm is between 1.0 and 10.0
                 size;
 

--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -1517,7 +1517,7 @@ Licensed under the MIT license.
                 dec = tickDecimals;
             }
 
-            var magn = parseFloat('1e-' + (-dec)),
+            var magn = parseFloat('1e' + (-dec)),
                 norm = delta / magn;
 
             if (norm > 2.25 && norm < 3 && (dec + 1) <= tickDecimals) {
@@ -1537,7 +1537,7 @@ Licensed under the MIT license.
                 dec = tickDecimals;
             }
 
-            var magn = parseFloat('1e-' + (-dec)),
+            var magn = parseFloat('1e' + (-dec)),
                 norm = delta / magn, // norm is between 1.0 and 10.0
                 size;
 

--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -1517,7 +1517,7 @@ Licensed under the MIT license.
                 dec = tickDecimals;
             }
 
-            var magn = parseFloat('1e-' + dec),
+            var magn = parseFloat('1e-' + (-dec)),
                 norm = delta / magn;
 
             if (norm > 2.25 && norm < 3 && (dec + 1) <= tickDecimals) {
@@ -1537,7 +1537,7 @@ Licensed under the MIT license.
                 dec = tickDecimals;
             }
 
-            var magn = parseFloat('1e-' + dec),
+            var magn = parseFloat('1e-' + (-dec)),
                 norm = delta / magn, // norm is between 1.0 and 10.0
                 size;
 

--- a/source/jquery.flot.logaxis.js
+++ b/source/jquery.flot.logaxis.js
@@ -35,7 +35,7 @@ formatters and transformers to and from logarithmic representation.
             val, range, vals = [];
 
         for (var power = log10Start; power <= log10End; power++) {
-            range = Math.pow(10, power);
+            range = parseFloat('1e' + power);
             for (var mult = 1; mult < 9; mult += rangeStep) {
                 val = range * mult;
                 vals.push(val);

--- a/source/jquery.flot.time.js
+++ b/source/jquery.flot.time.js
@@ -87,7 +87,7 @@ API.txt for details.
 
 		var formatMicroseconds = function(n, dec) {
 			if (dec < 6 && dec > 0) {
-				var magnitude = Math.pow(10,dec-6);
+				var magnitude = parseFloat('1e' + (dec-6));
 				n = Math.round(Math.round(n*magnitude)/magnitude);
 				n = ('00000' + n).slice(-6,-(6 - dec));
 			} else {
@@ -344,7 +344,7 @@ API.txt for details.
             if (opts.minTickSize !== null && opts.minTickSize !== undefined && opts.minTickSize[1] === "year") {
                 size = Math.floor(opts.minTickSize[0]);
             } else {
-                var magn = Math.pow(10, Math.floor(Math.log(axis.delta / timeUnitSize.year) / Math.LN10));
+                var magn = parseFloat('1e' + Math.floor(Math.log(axis.delta / timeUnitSize.year) / Math.LN10));
                 var norm = (axis.delta / timeUnitSize.year) / magn;
 
                 if (norm < 1.5) {


### PR DESCRIPTION
For the same reason as in https://github.com/ni-kismet/data-types/pull/45, that `Math.pow` have inconsistent behavior on chrome, flot has test fails.

This PR use the same way to fix it.