### PR TITLE
fix cssRule issue on Safari

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -63,9 +63,9 @@ module.exports = function(config) {
 
         // list of files / patterns to load in the browser
         files: sources.concat([
-            'source/getCORSCss.js',
             'node_modules/webcharts-development-settings/testsUtils/*.js',
             { pattern: 'tests/svgstyle.css', included: true, served: true },
+            { pattern: 'tests/corscss.css', included: true, served: true },
             'tests/*.Test.js'
         ]),
 
@@ -77,6 +77,7 @@ module.exports = function(config) {
         preprocessors: {
             '*.js': ['eslint'],
             'tests/**/*.js': ['eslint'],
+            'tests/getCORSCss.Test.js': ['eslint', 'browserify'],
             'source/*.js' : ['browserify'],
         },
         browserify: {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
   },
   "homepage": "https://github.com/flot/flot#readme",
   "devDependencies": {
-    "karma-browserify": "^6.0.0",
     "babelify": "~10.0.0",
-    "vinyl-source-stream": "~2.0.0",
     "browserify": "~16.2.3",
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.4.0",
@@ -36,6 +34,7 @@
     "gulp-uglify": "^3.0.0",
     "jasmine-core": "~2.7.0",
     "karma": "^1.3.0",
+    "karma-browserify": "^6.0.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.1.2",
     "karma-coveralls": "^1.1.2",
@@ -49,6 +48,7 @@
     "karma-spec-reporter": "0.0.32",
     "ljs": "^0.3.2",
     "tmp": "0.0.33",
+    "vinyl-source-stream": "~2.0.0",
     "webcharts-development-settings": "^1.0.9"
   },
   "dependencies": {

--- a/source/getCORSCss.js
+++ b/source/getCORSCss.js
@@ -68,7 +68,7 @@ function enableCrossOriginOnLinkAsync(document, link) {
  * @param {String} link A href string which not set "crossOrigin" attr and is CORS compared to current domain.
  */
 function enableSafariCrossOriginOnLinkAsync(document, link) {
-    if (!promiseMap.has(link) && !isCrossOriginEnabledForLink(document, link)) {
+    if (!isCrossOriginEnabledForLink(document, link)) {
         const newLink = document.createElement('link');
         newLink.rel = 'stylesheet';
         newLink.href = link;

--- a/source/getCORSCss.js
+++ b/source/getCORSCss.js
@@ -54,7 +54,6 @@ function enableCrossOriginOnLinkAsync(document, link) {
                 resolve();
             };
             newLink.onerror = function() {
-                window.console.log('error link');
                 reject();
             };
             linkBundle.parentNode.insertBefore(newLink, linkBundle.node);

--- a/source/getCORSCss.js
+++ b/source/getCORSCss.js
@@ -76,7 +76,8 @@ export const getCrossDomainCSSRules = async function(document) {
                 && !document.styleSheets[i].href.includes(document.styleSheets[i].ownerNode.baseURI)
                 && !document.styleSheets[i].ownerNode.crossOrigin) {
                 rules = [];
-                throw new TypeError('on Safari, the CORS cssRule Exception will be ignored and return null, which should be an error');
+                //On Safari, the CORS cssRule Exception will be ignored and return null, so we manually throw the exception for Safari to keep align with other browsers
+                throw new DOMException(`Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules`, 'SecurityError');
             }
         } catch (err) {
             await enableCrossOriginOnLinkAsync(document, document.styleSheets[i].href);

--- a/source/getCORSCss.js
+++ b/source/getCORSCss.js
@@ -77,7 +77,7 @@ export const getCrossDomainCSSRules = async function(document) {
                 && !document.styleSheets[i].ownerNode.crossOrigin) {
                 rules = [];
                 //On Safari, the CORS cssRule Exception will be ignored and return null, so we manually throw the exception for Safari to keep align with other browsers
-                throw new DOMException(`Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules`, 'SecurityError');
+                throw new DOMException("Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules", 'SecurityError');
             }
         } catch (err) {
             await enableCrossOriginOnLinkAsync(document, document.styleSheets[i].href);

--- a/tests/corscss.css
+++ b/tests/corscss.css
@@ -1,0 +1,5 @@
+/* Used in a test from getCORSCss.Test. */
+circle.FakeCORSCss {
+    stroke: whitesmoke;
+    stroke-width: 4px;
+}

--- a/tests/getCORSCss.Test.js
+++ b/tests/getCORSCss.Test.js
@@ -7,8 +7,10 @@ describe("getCrossDomainCSSRules", function() {
             throw new DOMException("Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules", 'SecurityError');
         });
         expect(() => {document.styleSheets[2].cssRules;}).toThrow(new DOMException("Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules", 'SecurityError'));
+        const styleSheetsCount = document.styleSheets.length;
         await getCrossDomainCSSRules(document);
         expect(document.styleSheets[2].ownerNode.crossOrigin).toBe('anonymous'); // should set crossOrigin attr successfully.
-        expect(document.styleSheets[1].ownerNode.crossOrigin).toBeNull(); //should not change if no exception threw.
+        expect(document.styleSheets[0].ownerNode.crossOrigin).toBeNull(); //should not change if no exception threw.
+        expect(document.styleSheets.length).toBe(styleSheetsCount); // the styleSheets length should be same after getCrossDomainCSSRules invoked.
     });
 });

--- a/tests/getCORSCss.Test.js
+++ b/tests/getCORSCss.Test.js
@@ -1,0 +1,15 @@
+/* eslint-disable */
+import {getCrossDomainCSSRules} from '../source/getCORSCss.js';
+describe("getCrossDomainCSSRules", function() {
+    it('should getCrossDomainCSSRules set new CORS link correctly', async function () {
+        // document.styleSheets[2] href based on http://localhost:9876/base/tests/corscss.css?
+        spyOnProperty(document.styleSheets[2], 'cssRules').and.callFake(() => {
+            throw new DOMException("Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules", 'SecurityError');
+        });
+        expect(() => {document.styleSheets[2].cssRules;}).toThrow(new DOMException("Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules", 'SecurityError'));
+        await getCrossDomainCSSRules(document);
+        expect(document.styleSheets[2].ownerNode.crossOrigin).toBe('anonymous');
+        expect(document.styleSheets[1].ownerNode.crossOrigin).toBeNull();
+
+    });
+});

--- a/tests/getCORSCss.Test.js
+++ b/tests/getCORSCss.Test.js
@@ -8,8 +8,7 @@ describe("getCrossDomainCSSRules", function() {
         });
         expect(() => {document.styleSheets[2].cssRules;}).toThrow(new DOMException("Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules", 'SecurityError'));
         await getCrossDomainCSSRules(document);
-        expect(document.styleSheets[2].ownerNode.crossOrigin).toBe('anonymous');
-        expect(document.styleSheets[1].ownerNode.crossOrigin).toBeNull();
-
+        expect(document.styleSheets[2].ownerNode.crossOrigin).toBe('anonymous'); // should set crossOrigin attr successfully.
+        expect(document.styleSheets[1].ownerNode.crossOrigin).toBeNull(); //should not change if no exception threw.
     });
 });


### PR DESCRIPTION
Background:
The origin issue is related to this [PR](https://github.com/flot/flot/pull/1651). and this fix is only for solving the same issue on Safari.

Why additional fix on Safari:
1. When CORS link loaded on Safari, the Safari will wrap the cssRule error and return null when we want to get styleSheet.cssRules. which will miss the try catch statement on the [original fix](https://github.com/flot/flot/blob/f33fd255bd53aa99d6f6d7f40ea6da96e8d07f62/source/getCORSCss.js#L69).
2. Seems Safari will load the new link immediately and synchronously if the link's href is same with other loaded link before.

let's pending this change here now until next Monday after another change reviewed.