### PR TITLE
Fix overloading of date types to allow using methods like "setFullYear()"

### DIFF
--- a/source/jquery.flot.time.js
+++ b/source/jquery.flot.time.js
@@ -35,15 +35,16 @@ API.txt for details.
 
             // Round epoch to 3 decimal accuracy
             microEpoch = Math.round(microEpoch*1000)/1000;
-            this.microEpoch = microEpoch;
 
             // Microseconds are stored as integers
             var seconds = microEpoch/1000;
             this.microseconds = 1000000 * (seconds - Math.floor(seconds));
         };
 
+        var oldGetTime = newDate.getTime.bind(newDate);
         newDate.getTime = function () {
-            return this.microEpoch;
+            var microEpoch = oldGetTime() + this.microseconds / 1000;
+            return microEpoch;
         };
 
         newDate.setTime = function (microEpoch) {
@@ -56,7 +57,7 @@ API.txt for details.
 
         newDate.setMicroseconds = function(microseconds) {
             // Replace the microsecond part (6 last digits) in microEpoch
-            var epochWithoutMicroseconds = 1000*Math.floor(this.microEpoch/1000);
+            var epochWithoutMicroseconds = oldGetTime();
             var newEpoch = epochWithoutMicroseconds + microseconds/1000;
             this.update(newEpoch);
         };

--- a/tests/jquery.flot.time.Test.js
+++ b/tests/jquery.flot.time.Test.js
@@ -56,6 +56,20 @@ describe('A Flot chart with absolute time axes', function () {
         ]);
     });
 
+    it('shows year time ticks', function () {
+        plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[-373597200000, 1], [1199142000000, 2]]], '%Y', 'milliseconds');
+
+        var ticks = plot.getAxes().xaxis.ticks
+        expect(firstAndLast(ticks)).toEqual([
+            {v: -373597200000, label: '1958'},
+            {v: 1199142000000, label: '2007'}
+        ]);
+        ticks.sort((a, b) => a.v - b.v);
+        for (var i = 1; i < ticks.length; i++) {
+            expect(ticks[i].v).toBeGreaterThan(ticks[i - 1].v);
+        }
+    });
+
     describe('date generator', function () {
         it('clamps values greater than Date() range to the limit of Date()', function () {
             var dateGenerator = $.plot.dateGenerator;


### PR DESCRIPTION
#1638 

To support microsecond dates, we add methods and properties to regular JS date objects to extend their functionality. However, these extended objects would not behave correctly when using some native date methods (e.g. `SetFullYear()`). We were storing a `microEpoch` value on the date object, which represented the whole date, but that value would not get updated when using any methods that we weren't overriding. 

Instead of keeping track of the whole date value ourselves, I made changes so that the native date object would maintain the millisecond-resolution date value. The microsecond wrapper will now only store the microsecond value. 