### PR TITLE
Update snap range to ticks behavior

### DIFF
--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -1338,7 +1338,7 @@ Licensed under the MIT license.
                     // make the ticks
                     setupTickGeneration(axis);
                     setMajorTicks(axis);
-                    snapRangeToTicks(axis, axis.ticks);
+                    snapRangeToTicks(axis, axis.ticks, series);
 
                     //for computing the endpoints precision, transformationHelpers are needed
                     setTransformationHelpers(axis);
@@ -1726,8 +1726,8 @@ Licensed under the MIT license.
             };
         }
 
-        function snapRangeToTicks(axis, ticks) {
-            if (axis.options.autoScale === "loose" && ticks.length > 0) {
+        function snapRangeToTicks(axis, ticks, series) {
+            if (axis.options.autoScale === "loose" && ticks.length > 0 && series.length > 0 && series[0].datapoints.points.length > 0) {
                 // snap to ticks
                 axis.min = Math.min(axis.min, ticks[0].v);
                 axis.max = Math.max(axis.max, ticks[ticks.length - 1].v);

--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -1727,7 +1727,16 @@ Licensed under the MIT license.
         }
 
         function snapRangeToTicks(axis, ticks, series) {
-            if (axis.options.autoScale === "loose" && ticks.length > 0 && series.length > 0 && series[0].datapoints.points.length > 0) {
+            var anyDataInSeries = function(series) {
+                for (var i = 0; i < series.length; i++) {
+                    if (series[i].datapoints.points.length > 0) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            if (axis.options.autoScale === "loose" && ticks.length > 0 && series.length > 0 && anyDataInSeries(series)) {
                 // snap to ticks
                 axis.min = Math.min(axis.min, ticks[0].v);
                 axis.max = Math.max(axis.max, ticks[ticks.length - 1].v);

--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -1728,15 +1728,10 @@ Licensed under the MIT license.
 
         function snapRangeToTicks(axis, ticks, series) {
             var anyDataInSeries = function(series) {
-                for (var i = 0; i < series.length; i++) {
-                    if (series[i].datapoints.points.length > 0) {
-                        return true;
-                    }
-                }
-
-                return false;
+                return series.some(e => e.datapoints.points.length > 0);
             }
-            if (axis.options.autoScale === "loose" && ticks.length > 0 && series.length > 0 && anyDataInSeries(series)) {
+
+            if (axis.options.autoScale === "loose" && ticks.length > 0 && anyDataInSeries(series)) {
                 // snap to ticks
                 axis.min = Math.min(axis.min, ticks[0].v);
                 axis.max = Math.max(axis.max, ticks[ticks.length - 1].v);

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -225,7 +225,7 @@ describe('flot', function() {
             expect(axes.yaxis.max).toBe(120);
         });
 
-        fit('should use the specified axis min and max for loose autoscaling if no data is set', function () {
+        it('should use the specified axis min and max for loose autoscaling if no data is set', function () {
             options.xaxis = {autoScale: 'loose', min: 1, max: 50};
             options.yaxis = {autoScale: 'loose', min: 1, max: 100};
             plot = $.plot(placeholder, [[]], options);

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -225,6 +225,21 @@ describe('flot', function() {
             expect(axes.yaxis.max).toBe(120);
         });
 
+        fit('should use the specified axis min and max for loose autoscaling if no data is set', function () {
+            options.xaxis = {autoScale: 'loose', min: 1, max: 50};
+            options.yaxis = {autoScale: 'loose', min: 1, max: 100};
+            plot = $.plot(placeholder, [[]], options);
+
+            var axes = plot.getAxes();
+            plot.setupGrid(true);
+            plot.draw();
+
+            expect(axes.xaxis.min).toBe(1);
+            expect(axes.xaxis.max).toBe(50);
+            expect(axes.yaxis.min).toBe(1);
+            expect(axes.yaxis.max).toBe(100);
+        });
+
         it('should keep the axis min 0 for loose autoscaling if all values are positive', function () {
             options.xaxis = {autoScale: 'loose', min: 0, max: 50};
             options.yaxis = {autoScale: 'loose', min: 0, max: 100};


### PR DESCRIPTION
When we set up the initial state of flot, then if we have no data we should honor the given min and max supplied for an axis, even if its autoscale setting is set to 'loose'.