### PR TITLE
jquery.flot.drawSeries.js: fixed a bug with trailing step interpolation

### DIFF
--- a/source/jquery.flot.drawSeries.js
+++ b/source/jquery.flot.drawSeries.js
@@ -39,22 +39,20 @@ This plugin is used by flot for drawing lines, plots, bars or area.
                 if(steps){
                     if (mx !== null && my !== null) {
                         // if middle point exists, transfer p2 -> p1 and p1 -> mp
-                        x2 = x1;
-                        y2 = y1;
                         x1 = mx;
                         y1 = my;
 
                         // 'remove' middle point
                         mx = null;
                         my = null;
-
-                        // subtract pointsize from i to have current point p1 handled again
-                        i -= ps;
                     } else if (y1 !== y2 && x1 !== x2) {
                         // create a middle point
                         y2 = y1;
                         mx = x2;
                         my = y1;
+
+                        // subtract pointsize from i to have current point p1 handled again
+                        i -= ps;
                     }
                 }
 


### PR DESCRIPTION
I noticed that when I introduced a bug in #1617 which causes the last line not to be drawn:
![tail_fail](https://user-images.githubusercontent.com/14980771/60604640-6117be00-9db8-11e9-88fd-cb048983e0fc.png)

After the fix, the result is as it should be:
![tail_fix](https://user-images.githubusercontent.com/14980771/60604679-6bd25300-9db8-11e9-944f-607bb6ac5474.png)
