### PR TITLE
Skip NaNs when drawing lines

### DIFF
--- a/source/jquery.flot.drawSeries.js
+++ b/source/jquery.flot.drawSeries.js
@@ -36,6 +36,12 @@ This plugin is used by flot for drawing lines, plots, bars or area.
                     continue;
                 }
 
+                if (isNaN(x1) || isNaN(x2) || isNaN(y1) || isNaN(y2)) {
+                    prevx = null;
+                    prevy = null;
+                    continue;
+                }
+
                 if(steps){
                     if (mx !== null && my !== null) {
                         // if middle point exists, transfer p2 -> p1 and p1 -> mp

--- a/tests/jquery.flot-drawSeries.Test.js
+++ b/tests/jquery.flot-drawSeries.Test.js
@@ -142,6 +142,24 @@ describe('drawSeries', function() {
             expect(ctx.fill).toHaveBeenCalled();
         });
 
+        /*
+        Should draw something like this (big gap between first two slopes, smaller gap between next two)
+
+         /    \    /
+        /      \  /
+        */
+        it('should move pen when NaNs are encountered', function () {
+            series.datapoints.points = [-1, -1, 0, 0, 1, NaN, 2, NaN, 3, 0, 4, -1, NaN, 34, 6, -1, 7, 0];
+
+            spyOn(ctx, 'moveTo').and.callThrough();
+            spyOn(ctx, 'lineTo').and.callThrough();
+
+            drawSeriesLines(series, ctx, plotOffset, plotWidth, plotHeight, null, getColorOrGradient);
+
+            expect(ctx.moveTo).toHaveBeenCalledTimes(3);
+            expect(ctx.lineTo).toHaveBeenCalledTimes(3);
+        });
+
         it('should draw area fills before and after nulls', function () {
             const format = {
                 x: true,


### PR DESCRIPTION
If we have NaNs present in our data when drawing lines we should be moving the pen to the next valid data point and pick up drawing there.