### PR TITLE
Fix broken distribution for jquery.flot.hover.js

### DIFF
--- a/source/jquery.flot.hover.js
+++ b/source/jquery.flot.hover.js
@@ -50,7 +50,7 @@ the tooltip from webcharts).
 
             if (o.grid.hoverable || o.grid.clickable) {
                 eventHolder[0].addEventListener('touchevent', triggerCleanupEvent, false);
-                eventHolder[0].addEventListener('tap', tap.generatePlothoverEvent, false);
+                eventHolder[0].addEventListener('tap', generatePlothoverEvent, false);
             }
 
             if (o.grid.clickable) {
@@ -71,7 +71,7 @@ the tooltip from webcharts).
         }
 
         function shutdown(plot, eventHolder) {
-            eventHolder[0].removeEventListener('tap', tap.generatePlothoverEvent);
+            eventHolder[0].removeEventListener('tap', generatePlothoverEvent);
             eventHolder[0].removeEventListener('touchevent', triggerCleanupEvent);
             eventHolder.unbind("mousemove", onMouseMove);
             eventHolder.unbind("mouseleave", onMouseLeave);
@@ -79,23 +79,22 @@ the tooltip from webcharts).
             highlights = [];
         }
 
-        var tap = {
-            generatePlothoverEvent: function (e) {
-                var o = plot.getOptions(),
-                    newEvent = new CustomEvent('mouseevent');
 
-                //transform from touch event to mouse event format
-                newEvent.pageX = e.detail.changedTouches[0].pageX;
-                newEvent.pageY = e.detail.changedTouches[0].pageY;
-                newEvent.clientX = e.detail.changedTouches[0].clientX;
-                newEvent.clientY = e.detail.changedTouches[0].clientY;
+        function generatePlothoverEvent(e) {
+            var o = plot.getOptions(),
+                newEvent = new CustomEvent('mouseevent');
 
-                if (o.grid.hoverable) {
-                    doTriggerClickHoverEvent(newEvent, eventType.hover, 30);
-                }
-                return false;
+            //transform from touch event to mouse event format
+            newEvent.pageX = e.detail.changedTouches[0].pageX;
+            newEvent.pageY = e.detail.changedTouches[0].pageY;
+            newEvent.clientX = e.detail.changedTouches[0].clientX;
+            newEvent.clientY = e.detail.changedTouches[0].clientY;
+
+            if (o.grid.hoverable) {
+                doTriggerClickHoverEvent(newEvent, eventType.hover, 30);
             }
-        };
+            return false;
+        }
 
         function doTriggerClickHoverEvent(event, eventType, searchDistance) {
             var series = plot.getData();


### PR DESCRIPTION
Because of the refactoring done in https://github.com/flot/flot/pull/1683, the 'tap' object was being used before it was defined in the hover init code. This doesn't actually cause problems when using the source, but the minified/transpiled distribution was broken. This has been a problem before (https://github.com/flot/flot/pull/1631) so I turned the tap object into a function. 

I tested hovering on some examples using the minified source and everything works. 