### PR TITLE
Move when reset happens

### DIFF
--- a/source/jquery.flot.hover.js
+++ b/source/jquery.flot.hover.js
@@ -241,7 +241,7 @@ the tooltip from webcharts).
             return -1;
         }
 
-        function processRawData() {
+        function processDatapoints() {
             triggerCleanupEvent();
             doTriggerClickHoverEvent(lastMouseMoveEvent, eventType.hover);
         }
@@ -325,7 +325,7 @@ the tooltip from webcharts).
             plot.unhighlight = unhighlight;
             if (options.grid.hoverable || options.grid.clickable) {
                 plot.hooks.drawOverlay.push(drawOverlay);
-                plot.hooks.processRawData.push(processRawData);
+                plot.hooks.processDatapoints.push(processDatapoints);
             }
 
             lastMouseMoveEvent = plot.getPlaceholder()[0].lastMouseMoveEvent;

--- a/source/jquery.flot.hover.js
+++ b/source/jquery.flot.hover.js
@@ -241,8 +241,11 @@ the tooltip from webcharts).
             return -1;
         }
 
-        function processDatapoints() {
+        function processRawData() {
             triggerCleanupEvent();
+        }
+
+        function setupGrid() {
             doTriggerClickHoverEvent(lastMouseMoveEvent, eventType.hover);
         }
 
@@ -325,7 +328,8 @@ the tooltip from webcharts).
             plot.unhighlight = unhighlight;
             if (options.grid.hoverable || options.grid.clickable) {
                 plot.hooks.drawOverlay.push(drawOverlay);
-                plot.hooks.processDatapoints.push(processDatapoints);
+                plot.hooks.processRawData.push(processRawData);
+                plot.hooks.setupGrid.push(setupGrid);
             }
 
             lastMouseMoveEvent = plot.getPlaceholder()[0].lastMouseMoveEvent;

--- a/tests/jquery.flot.hover.Test.js
+++ b/tests/jquery.flot.hover.Test.js
@@ -190,8 +190,11 @@ describe("flot hover plugin", function () {
         });
 
         it('should update the current hover point to the placeholder when the plot created again', function () {
+            var hovered = false;
             plot = $.plot(placeholder, [ [ [0, 0], [2, 3], [10, 10] ] ], options);
-
+            $(placeholder).bind("plothover", function (event, pos, item) {
+                hovered = true;
+            });
             var eventHolder = plot.getEventHolder(),
                 offset = plot.getPlotOffset(),
                 axisx = plot.getXAxes()[0],
@@ -202,11 +205,12 @@ describe("flot hover plugin", function () {
 
             let evt = simulate.mouseMove(eventHolder, x, y, noButton);
             jasmine.clock().tick(1000);
-
+            hovered = false;
             plot = $.plot(placeholder, [ [ [0, 0], [2, 3], [10, 10] ] ], options);
 
             expect(plot.getPlaceholder()[0].lastMouseMoveEvent.originalEvent.x).toEqual(evt.x);
             expect(plot.getPlaceholder()[0].lastMouseMoveEvent.originalEvent.y).toEqual(evt.y);
+            expect(hovered).toEqual(true);
         });
 
         it('should highlight a bar when hovered', function() {


### PR DESCRIPTION
Reset happened in processRawData but there each axis is listed as used = false. This can cause a crash if setData is called because pos.x and pos.y are undefined (this happened when I modified the interacting example to update on a timer). Instead do the reset in processDatapoints where axis.used = true