### PR TITLE
Hovering on bars with three datapoints (x, y, y2) does not work #1691

### DIFF
--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -2608,17 +2608,27 @@ Licensed under the MIT license.
 
             var foundIndex = -1;
             for (var j = 0; j < points.length; j += ps) {
-                var x = points[j], y = points[j + 1];
+                var x = points[j], y = points[j + 1], y2;
                 if (x == null)
                     continue;
 
                 // for a bar graph, the cursor must be inside the bar
-                if (series.bars.horizontal ?
-                    (mx <= Math.max(bottom, x) && mx >= Math.min(bottom, x) &&
-                        my >= y + barLeft && my <= y + barRight) :
-                    (mx >= x + barLeft && mx <= x + barRight &&
-                        my >= Math.min(bottom, y) && my <= Math.max(bottom, y)))
-                        foundIndex = j / ps;
+                if (ps >= 3 && (y2 = points[j + 2]) != null) {
+                    // we have a third coordinate which is the bottom of the filled area/bar
+                    if (series.bars.horizontal ?
+                        (mx <= Math.max(bottom, x) && mx >= Math.min(bottom, x) &&
+                            my >= y + barLeft && my <= y + barRight) :
+                        (mx >= x + barLeft && mx <= x + barRight &&
+                            my >= Math.min(y2, y) && my <= Math.max(y2, y)))
+                            foundIndex = j / ps;
+                } else {
+                    if (series.bars.horizontal ?
+                        (mx <= Math.max(bottom, x) && mx >= Math.min(bottom, x) &&
+                            my >= y + barLeft && my <= y + barRight) :
+                        (mx >= x + barLeft && mx <= x + barRight &&
+                            my >= Math.min(bottom, y) && my <= Math.max(bottom, y)))
+                            foundIndex = j / ps;
+                }
             }
 
             return foundIndex;


### PR DESCRIPTION
When you try to hover on bars that are manually stacked on top (example: 0-80, 81-120, 121-200, ..) you can only hover over the top one since only the top value (y) is considered:

Reason is removal of code previously found in 0.8.3:

findNearbyBar no longer gets y2 (called b here):

Before:
var x = points[j], y = points[j + 1], b = points[j + 2];
Now:
var x = points[j], y = points[j + 1];

Before:
my >= Math.min(b, y) && my <= Math.max(b, y)
Now:
my >= Math.min(bottom, y) && my <= Math.max(bottom, y)

Reverting the code to 0.8.3 and everything works again, but there is now a new option called fillTowards. I think adding something like "If fillTowards is not set, use b, otherwise use fillTowards" would be the correct fix.