### PR TITLE
Fix bar hovering for charts with bottom points specified 

### DIFF
--- a/source/jquery.flot.drawSeries.js
+++ b/source/jquery.flot.drawSeries.js
@@ -587,7 +587,7 @@ This plugin is used by flot for drawing lines, plots, bars or area.
                 var points = datapoints.points,
                     ps = datapoints.pointsize,
                     fillTowards = series.bars.fillTowards || 0,
-                    calculatedBottom = fillTowards > axisy.min ? Math.min(axisy.max, fillTowards) : axisy.min;
+                    defaultBottom = fillTowards > axisy.min ? Math.min(axisy.max, fillTowards) : axisy.min;
 
                 for (var i = 0; i < points.length; i += ps) {
                     if (points[i] == null) {
@@ -595,7 +595,7 @@ This plugin is used by flot for drawing lines, plots, bars or area.
                     }
 
                     // Use third point as bottom if pointsize is 3
-                    var bottom = ps === 3 ? points[i + 2] : calculatedBottom;
+                    var bottom = ps === 3 ? points[i + 2] : defaultBottom;
                     drawBar(points[i], points[i + 1], bottom, barLeft, barRight, fillStyleCallback, axisx, axisy, ctx, series.bars.horizontal, series.bars.lineWidth);
                 }
             }

--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -2604,7 +2604,7 @@ Licensed under the MIT license.
             barRight = barLeft + barWidth;
 
             var fillTowards = series.bars.fillTowards || 0;
-            var bottom = fillTowards > series.yaxis.min ? Math.min(series.yaxis.max, fillTowards) : series.yaxis.min;
+            var defaultBottom = fillTowards > series.yaxis.min ? Math.min(series.yaxis.max, fillTowards) : series.yaxis.min;
 
             var foundIndex = -1;
             for (var j = 0; j < points.length; j += ps) {
@@ -2612,6 +2612,7 @@ Licensed under the MIT license.
                 if (x == null)
                     continue;
 
+                var bottom = ps === 3 ? points[j + 2] : defaultBottom;
                 // for a bar graph, the cursor must be inside the bar
                 if (series.bars.horizontal ?
                     (mx <= Math.max(bottom, x) && mx >= Math.min(bottom, x) &&

--- a/tests/jquery.flot.hover.Test.js
+++ b/tests/jquery.flot.hover.Test.js
@@ -232,5 +232,31 @@ describe("flot hover plugin", function () {
 
             expect(getEntireCanvasData(canvas)).toContainPixelColor(rgba(10, 20, 30, 1));
         });
+
+        it('should correctly highlight bars with bottom points specified', function() {
+            options.series.bars = { show: true, barWidth: 0.5 };
+            options.series.lines = undefined;
+            plot = $.plot(placeholder, [ [ [0, 5, 2], [1, 7, 2], [2, 6, 2] ] ], options);
+
+            var eventHolder = plot.getEventHolder(),
+                canvas = eventHolder,
+                offset = plot.getPlotOffset(),
+                axisx = plot.getXAxes()[0],
+                axisy = plot.getYAxes()[0],
+                x = axisx.p2c(1.25) + offset.left,
+                y = axisy.p2c(1) + offset.top,
+                noButton = 0;
+
+            simulate.mouseMove(eventHolder, x, y, noButton);
+            jasmine.clock().tick(100);
+
+            expect(getEntireCanvasData(canvas)).not.toContainPixelColor(rgba(10, 20, 30, 1));
+
+            y = axisy.p2c(4) + offset.top;
+            simulate.mouseMove(eventHolder, x, y, noButton);
+            jasmine.clock().tick(100);
+
+            expect(getEntireCanvasData(canvas)).toContainPixelColor(rgba(10, 20, 30, 1));
+        });
     });
 });


### PR DESCRIPTION
This fix is primarily relevant for stacked bar charts. In the current version of flot, if you try to hover on stacked bars, you will only receive hover events for the last series in the data. This is because `findNearbyBar` doesn't take into account series with a point size of 3 (where the 3rd point is the bottom of the bar). I used the same pattern from `drawSeriesBars` to fix this. I also renamed a variable in both places to be closer to its actual meaning. 