### PR TITLE
Update jquery.flot.selection.js

### DIFF
--- a/source/jquery.flot.selection.js
+++ b/source/jquery.flot.selection.js
@@ -104,9 +104,7 @@ The plugin allso adds the following methods to the plot object:
         // make this plugin much slimmer.
         var savedhandlers = {};
 
-        var mouseUpHandler = null;
-
-        function onMouseMove(e) {
+        function onDrag(e) {
             if (selection.active) {
                 updateSelection(e);
 
@@ -114,7 +112,7 @@ The plugin allso adds the following methods to the plot object:
             }
         }
 
-        function onMouseDown(e) {
+        function onDragStart(e) {
             var o = plot.getOptions();
             // only accept left-click
             if (e.which !== 1 || o.selection.mode === null) return;
@@ -138,15 +136,9 @@ The plugin allso adds the following methods to the plot object:
             setSelectionPos(selection.first, e);
 
             selection.active = true;
-
-            // this is a bit silly, but we have to use a closure to be
-            // able to whack the same handler again
-            mouseUpHandler = function (e) { onMouseUp(e); };
-
-            $(document).one("mouseup", mouseUpHandler);
         }
 
-        function onMouseUp(e) {
+        function onDragEnd(e) {
             mouseUpHandler = null;
 
             // revert drag stuff for old-school browsers
@@ -360,8 +352,9 @@ The plugin allso adds the following methods to the plot object:
         plot.hooks.bindEvents.push(function(plot, eventHolder) {
             var o = plot.getOptions();
             if (o.selection.mode != null) {
-                eventHolder.mousemove(onMouseMove);
-                eventHolder.mousedown(onMouseDown);
+                plot.addEventHandler("dragstart", onDragStart, eventHolder, 0);
+                plot.addEventHandler("drag", onDrag, eventHolder, 0);
+                plot.addEventHandler("dragend", onDragEnd, eventHolder, 0);
             }
         });
 
@@ -503,12 +496,9 @@ The plugin allso adds the following methods to the plot object:
         });
 
         plot.hooks.shutdown.push(function (plot, eventHolder) {
-            eventHolder.unbind("mousemove", onMouseMove);
-            eventHolder.unbind("mousedown", onMouseDown);
-
-            if (mouseUpHandler) {
-                $(document).unbind("mouseup", mouseUpHandler);
-            }
+            eventHolder.unbind("dragstart", onDragStart);
+            eventHolder.unbind("drag", onDrag);
+            eventHolder.unbind("dragend", onDragEnd);
         });
     }
 

--- a/tests/jquery.flot.TestDragPlugin.Test.js
+++ b/tests/jquery.flot.TestDragPlugin.Test.js
@@ -1,0 +1,50 @@
+/* Test Flot plugin for purposes of testing in conjunction with other plugins that use drag events
+
+Copyright (c) 2007-2014 IOLA and Ole Laursen.
+Licensed under the MIT license.
+*/
+
+(function ($) {
+    function init(plot) {
+        function onDrag(e) {
+            e.stopImmediatePropagation();
+            e.preventDefault();
+        }
+
+        function onDragStart(e) {
+            e.stopImmediatePropagation();
+            e.preventDefault();
+        }
+
+        function onDragEnd(e) {
+            e.stopImmediatePropagation();
+            e.preventDefault();
+        }
+
+        plot.hooks.bindEvents.push(function(plot, eventHolder) {
+            var o = plot.getOptions();
+            if (o.testDrag.on === true) {
+                plot.addEventHandler("dragstart", onDragStart, eventHolder, 10);
+                plot.addEventHandler("drag", onDrag, eventHolder, 10);
+                plot.addEventHandler("dragend", onDragEnd, eventHolder, 10);
+            }
+        });
+
+        plot.hooks.shutdown.push(function (plot, eventHolder) {
+            eventHolder.unbind("dragstart", onDragStart);
+            eventHolder.unbind("drag", onDrag);
+            eventHolder.unbind("dragend", onDragEnd);
+        });
+    }
+
+    $.plot.plugins.push({
+        init: init,
+        options: {
+            testDrag: {
+                on: false // true or false
+            }
+        },
+        name: 'testDragPlugin',
+        version: '1.1'
+    });
+})(jQuery);


### PR DESCRIPTION
Fix selection plugin to declare interactive event handlers in a similar way to the navigate plugin. This makes it behave nicer when used with other plugins like the cursor plugin which you can interact with using the same events.