### PR TITLE
Fixed issue with inconsistent millisecond values on microsecond dates

### DIFF
--- a/source/jquery.flot.time.js
+++ b/source/jquery.flot.time.js
@@ -37,8 +37,7 @@ API.txt for details.
             microEpoch = Math.round(microEpoch*1000)/1000;
 
             // Microseconds are stored as integers
-            var seconds = microEpoch/1000;
-            this.microseconds = 1000000 * (seconds - Math.floor(seconds));
+            this.microseconds = 1000 * (microEpoch - Math.floor(microEpoch));
         };
 
         var oldGetTime = newDate.getTime.bind(newDate);
@@ -56,7 +55,6 @@ API.txt for details.
         };
 
         newDate.setMicroseconds = function(microseconds) {
-            // Replace the microsecond part (6 last digits) in microEpoch
             var epochWithoutMicroseconds = oldGetTime();
             var newEpoch = epochWithoutMicroseconds + microseconds/1000;
             this.update(newEpoch);
@@ -86,16 +84,18 @@ API.txt for details.
 			return n.length == 1 ? pad + n : n;
 		};
 
-		var formatMicroseconds = function(n, dec) {
-			if (dec < 6 && dec > 0) {
-				var magnitude = parseFloat('1e' + (dec-6));
-				n = Math.round(Math.round(n*magnitude)/magnitude);
-				n = ('00000' + n).slice(-6,-(6 - dec));
+		var formatSubSeconds = function(milliseconds, microseconds, numberDecimalPlaces) {
+            var totalMicroseconds = milliseconds * 1000 + microseconds;
+            var formattedString;
+			if (numberDecimalPlaces < 6 && numberDecimalPlaces > 0) {
+				var magnitude = parseFloat('1e' + (numberDecimalPlaces - 6));
+				totalMicroseconds = Math.round(Math.round(totalMicroseconds * magnitude) / magnitude);
+				formattedString = ('00000' + totalMicroseconds).slice(-6,-(6 - numberDecimalPlaces));
 			} else {
-                n = Math.round(n)
-				n = ('00000' + n).slice(-6);
+                totalMicroseconds = Math.round(totalMicroseconds)
+				formattedString = ('00000' + totalMicroseconds).slice(-6);
 			}
-			return n;
+			return formattedString;
 		};
 
         var r = [];
@@ -142,7 +142,7 @@ API.txt for details.
 					case 'q':
 						c = "" + (Math.floor(d.getMonth() / 3) + 1); break;
 					case 'S': c = leftPad(d.getSeconds()); break;
-					case 's': c = "" + formatMicroseconds(d.getMicroseconds(),decimals); break;
+					case 's': c = "" + formatSubSeconds(d.getMilliseconds(), d.getMicroseconds(), decimals); break;
 					case 'y': c = leftPad(d.getFullYear() % 100); break;
 					case 'Y': c = "" + d.getFullYear(); break;
 					case 'p': c = (isAM) ? ("" + "am") : ("" + "pm"); break;

--- a/tests/jquery.flot.time.Test.js
+++ b/tests/jquery.flot.time.Test.js
@@ -90,6 +90,12 @@ describe('A Flot chart with absolute time axes', function () {
                 {v: 1000000, label: '1970/01/01 00:01'}
             ]);
         });
+
+        it('persists millisecond values', function() {
+            var dateGenerator = $.plot.dateGenerator;
+
+            expect(dateGenerator(123123, { timeBase: 'microseconds' }).getTime()).toEqual(123.123);
+        });
     });
 
     describe('sub-second ticks', function () {


### PR DESCRIPTION
In issue #1707, @skortchmark9 pointed out that we are double-counting millisecond values on microsecond date objects. When the date is set, we pass the epoch (including milliseconds) to the base Date `setTime` method, and then we would also keep the millisecond value in the `microseconds` field. I changed the implementation so that now the `microseconds` field only stores the microseconds value (which I meant to be the case in #1660, but missed an aspect of it).