### PR TITLE
Clear pie chart hover highlights on mouseleave

### DIFF
--- a/source/jquery.flot.pie.js
+++ b/source/jquery.flot.pie.js
@@ -119,6 +119,7 @@ More detail and specific examples can be found in the included HTML file.
             if (options.series.pie.show) {
                 if (options.grid.hoverable) {
                     eventHolder.unbind("mousemove").mousemove(onMouseMove);
+                    eventHolder.bind("mouseleave", onMouseMove);
                 }
                 if (options.grid.clickable) {
                     eventHolder.unbind("click").click(onClick);

--- a/source/jquery.flot.pie.js
+++ b/source/jquery.flot.pie.js
@@ -127,6 +127,13 @@ More detail and specific examples can be found in the included HTML file.
             }
         });
 
+        plot.hooks.shutdown.push(function (plot, eventHolder) {
+            eventHolder.unbind("mousemove", onMouseMove);
+            eventHolder.unbind("mouseleave", onMouseMove);
+            eventHolder.unbind("click", onClick);
+            highlights = [];
+        });
+
         plot.hooks.processDatapoints.push(function(plot, series, data, datapoints) {
             var options = plot.getOptions();
             if (options.series.pie.show) {


### PR DESCRIPTION
If the last mousemove event on a pie chart is over a slice, it will get stuck in the highlight state. We need to trigger a hover event when the mouse leaves the placeholder element so that highlights get cleared. 

This is especially a problem when the radius of a pie chart is 1, such that there is no gap between the edges of slices and the container element:

![image](https://user-images.githubusercontent.com/9257800/68346224-323c8c00-00b9-11ea-9e84-81e2fd4db461.png)
