### PR TITLE
Adding rect element to legend svg

### DIFF
--- a/source/jquery.flot.legend.js
+++ b/source/jquery.flot.legend.js
@@ -116,6 +116,13 @@
                 iconHtml += getEntryIconHtml(shape);
             }
 
+            // pie
+            if (options.legend.showColorRect) {
+                let updatedYPos = Number(shape.yPos.replace('em', '')) + .5 + 'em'
+                let updatedXPos = Number(shape.xPos.replace('px', '')) + 7 + 'px'
+                iconHtml = `<rect x="${updatedXPos}" y="${updatedYPos}" height="14" width="14" style="fill: ${entry.color};stroke-width:1;stroke:rgb(0,0,0);"/>${iconHtml}`
+            }
+            
             labelHtml = '<text x="' + shape.xPos + '" y="' + shape.yPos + '" text-anchor="start"><tspan dx="2em" dy="1.2em">' + shape.label + '</tspan></text>'
             html[j++] = '<g>' + iconHtml + labelHtml + '</g>';
         }


### PR DESCRIPTION
Adding a rect object that can be shown with setting legend option `showColorRect: true`

I tried creating a PR with the 0.9: work branch as seen in the CONTRIBUTING.d document but there hadn't been any new commits since may 2014?

Anyway, I did not see a way to show in the legend for a pie chart which label lined up to what color. I also could not see anything in documentation for this. Creating this pr for a simple contribution if maintainers want it. I'm open to discuss further if there is a better placement for this. Or if it's not needed feel free to delete PR, this was mostly a quick solution.

Thanks,
Connor