### PR TITLE
Cancel jQuery animation queue on hover off

### DIFF
--- a/examples/interacting/index.html
+++ b/examples/interacting/index.html
@@ -96,7 +96,7 @@
 						.css({top: item.pageY+5, left: item.pageX+5})
 						.fadeIn(200);
 				} else {
-					$("#tooltip").hide();
+					$("#tooltip").stop().hide();
 				}
 			}
 		});


### PR DESCRIPTION
Since jQuery fadeIn is used there is a delay before the tooltip shows up in which time the user may still be moving the mouse.   It is possible to have tooltip show up after user has already removed cursor from canvas.  See:  https://stackoverflow.com/a/29588856/562644