### PR TITLE
Update the selection example.

### DIFF
--- a/examples/selection/index.html
+++ b/examples/selection/index.html
@@ -5,6 +5,7 @@
 	<title>Flot Examples: Selection</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../source/jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../lib/jquery.event.drag.js"></script>
 	<script language="javascript" type="text/javascript" src="../../source/jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../source/jquery.colorhelpers.js"></script>
 	<script language="javascript" type="text/javascript" src="../../source/jquery.flot.js"></script>


### PR DESCRIPTION
After the changes made in d1fef617, selection will not work unless the `jquery.event.drag.js` library is included.