### PR TITLE
Fixed multi line SVG text spacing

### DIFF
--- a/source/jquery.canvaswrapper.js
+++ b/source/jquery.canvaswrapper.js
@@ -460,7 +460,7 @@ don't work unless the canvas is attached to the DOM.
                 tspan = element.childNodes[i];
             }
             tspan.textContent = lines[i];
-            offset = i * 1 + 'em';
+            offset = (i === 0 ? 0 : 1) + 'em';
             tspan.setAttributeNS(null, 'dy', offset);
             tspan.setAttributeNS(null, 'x', x);
         }

--- a/tests/jquery.flot.canvaswrapper.Test.js
+++ b/tests/jquery.flot.canvaswrapper.Test.js
@@ -223,6 +223,18 @@ describe('CanvasWrapper', function() {
         expect(elem.childNodes.length).toBe(4);
     });
 
+    it('should evenly space multi line text', function() {
+        var canvas = newCanvas(placeholder);
+        canvas.addText('layerA', 100, 200, '1<br>2<br>3<br>4', 'a');
+        canvas.render();
+
+        var elem = placeholder.find('.a')[0];
+        expect(elem.childNodes[0].getAttribute('dy')).toBe('0em');
+        for (var i = 1; i < 4; i++) {
+            expect(elem.childNodes[i].getAttribute('dy')).toBe('1em');
+        }
+    });
+
     it('should update the cache position of the elements', function() {
         var canvas = newCanvas(placeholder);
         canvas.addText('layerA', 100, 200, '123', 'a');


### PR DESCRIPTION
I noticed when testing multi-line axis names that flot doesn't render SVG text with more than 2 lines correctly. After the second line, the lines are spaced out farther than expected.
![LineSpacingOld](https://user-images.githubusercontent.com/5454342/74059894-78520600-49ae-11ea-9c4a-55885f5b89d5.PNG)
It looks like we're incorrectly configuring the line spacing in `addTspanElements()` in jquery.canvaswrapper.js. We set the `dy` attribute in each `tspan` element (each of which holds a line of text) to move the text down the page. `dy` moves the `tspan` relative to the previous text - in this case, the previous `tspan`. We were setting `dy` to the index of the line, which would move each line progressively further away from the previous line. I changed it so that we always move each subsequent line only `1em` from the previous line.
![LineSpacingFixed](https://user-images.githubusercontent.com/5454342/74060277-3e353400-49af-11ea-9f8b-c0d48ba0bd42.PNG)
