### PR TITLE
Don't show y-axis endpoints for horizontal bar charts

### DIFF
--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -1761,7 +1761,7 @@ Licensed under the MIT license.
             }
             if (axis.options.showTickLabels === 'all') {
                 var associatedSeries = series.filter(function(s) {
-                        return s.xaxis === axis;
+                        return s.bars.horizontal ? s.yaxis === axis : s.xaxis === axis;
                     }),
                     notAllBarSeries = associatedSeries.some(function(s) {
                         return !s.bars.show;

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -951,6 +951,37 @@ describe('flot', function() {
                 expect(yaxis.max).toEqual(ticks[ticks.length - 1].v);
             });
 
+            it('should not show y axis endpoints for horizontal bars with showTickLabels = all', function() {
+                var plot = $.plot(placeholder, [[[1, -3], [15, 30], [7, 20], [2, 5]]], {
+                    xaxis: {
+                        autoScale: 'exact',
+                        showTickLabels: 'all'
+                    },
+                    yaxis: {
+                        autoScale: 'exact',
+                        showTickLabels: 'all'
+                    },
+                    series: {
+                        bars: {
+                            lineWidth: 1,
+                            show: true,
+                            fillColor: 'blue',
+                            barWidth: 0.8,
+                            horizontal: true
+                        }
+                    }
+                });
+
+                var xaxis = plot.getXAxes()[0],
+                    yaxis = plot.getYAxes()[0],
+                    ticks = yaxis.ticks;
+                expect(yaxis.min).not.toEqual(ticks[0].v);
+                expect(yaxis.max).not.toEqual(ticks[ticks.length - 1].v);
+                ticks = xaxis.ticks;
+                expect(xaxis.min).toEqual(ticks[0].v);
+                expect(xaxis.max).toEqual(ticks[ticks.length - 1].v);
+            });
+
             it('should show endpoints for multiple series type where showTickLabels = all', function() {
                 var plot = $.plot(placeholder, [{
                     data: [[-3, 2], [20, 15], [4, 5]],


### PR DESCRIPTION
Prevents this issue:
<img width="880" alt="Screen Shot 2020-05-06 at 2 56 31 PM" src="https://user-images.githubusercontent.com/9257800/81227269-c4164a80-8fb1-11ea-9d37-9817b3a5f8f9.png">
