### PR TITLE
3rd coordinate should swap axes when bars are horizontal

### DIFF
--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -826,8 +826,8 @@ Licensed under the MIT license.
                         var expectedPs = s.datapoints.pointsize != null ? s.datapoints.pointsize : (s.data && s.data[0] && s.data[0].length ? s.data[0].length : 3);
                         if (expectedPs > 2) {
                             format.push({
-                                x: false,
-                                y: true,
+                                x: s.bars.horizontal,
+                                y: !s.bars.horizontal,
                                 number: true,
                                 required: false,
                                 computeRange: s.yaxis.options.autoScale !== 'none',

--- a/source/jquery.flot.stack.js
+++ b/source/jquery.flot.stack.js
@@ -63,8 +63,8 @@ charts or filled areas).
             }
 
             datapoints.format.push({
-                x: false,
-                y: true,
+                x: s.bars.horizontal,
+                y: !s.bars.horizontal,
                 number: true,
                 required: false,
                 computeRange: s.yaxis.options.autoScale !== 'none',

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -347,6 +347,20 @@ describe('flot', function() {
             expect(limits.ymin).toBe(1);
             expect(limits.ymax).toBe(3);
         });
+
+        it('should correctly compute the minimum and maximum when 3rd coordinate is specified for horizontal bars', function () {
+            options.series.points.show = false;
+            options.series.bars = { show: true, horizontal: true };
+            plot = $.plot(placeholder, [[[10, 0, 5], [12, 1, 5], [8, 2, 5]]], options);
+
+            var series = plot.getData();
+            var limits = plot.computeRangeForDataSeries(series[0], true);
+
+            expect(limits.xmin).toBe(5);
+            expect(limits.xmax).toBe(12);
+            expect(limits.ymin).toBe(0);
+            expect(limits.ymax).toBe(2);
+        });
     });
 
     describe('adjustSeriesDataRange', function() {


### PR DESCRIPTION
Fixes issues like this where the axis of a horizontal bar chart is squished:
![image](https://user-images.githubusercontent.com/9257800/111234338-53ba5b80-85bc-11eb-83df-3c2e7b6a3587.png)

We can't assume that the 3rd coordinate (used to specify the bottom of a filled area/bar) will always be for a Y Axis, because if you're using horizontal bars, then the X and Y data should be transposed. Without this change, `computeRangeForDataSeries` was using the 3rd coordinate of a datapoints set as part of the min/max calculation for the wrong axis. 