### PR TITLE
Fix precission when tickSize = 2.5 (fix null reference)

### DIFF
--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -1520,7 +1520,7 @@ Licensed under the MIT license.
             var magn = parseFloat('1e' + (-dec)),
                 norm = delta / magn;
 
-            if (norm > 2.25 && norm < 3 && (dec + 1) <= tickDecimals) {
+            if (norm > 2.25 && norm < 3 && (tickDecimals == null || (dec + 1) <= tickDecimals)) {
                 //we need an extra decimals when tickSize is 2.5
                 ++dec;
             }


### PR DESCRIPTION
Issue:  ticks: 0 - 0.25 - 0.5 - 0.75 - 1 will be incorrectly rounded to 0 - 0.3 - 0.5 - 0.8 - 1

This is visible in the examples: http://www.flotcharts.org/flot/examples/axes-tickLabels/index.html
![image](https://user-images.githubusercontent.com/6316468/123375092-7deec280-d588-11eb-9bb1-52ae0d79d9d6.png)
In the image above the horizontal ticks should be 10017.00 - 10017.25 - x.50 - x.75 etc. 


This is caused by a null reference to `axis.tickDecimals`. When this is `null` the extra decimal for `tickRange` 2.5 is not added.


