### PR TITLE
Fix time plugin not to skip ticks & Avoid infinite loop when using microsecond min tick size

### DIFF
--- a/source/jquery.flot.time.js
+++ b/source/jquery.flot.time.js
@@ -31,10 +31,11 @@ API.txt for details.
 
         var oldSetTime = newDate.setTime.bind(newDate);
         newDate.update = function(microEpoch) {
-            oldSetTime(microEpoch);
 
             // Round epoch to 3 decimal accuracy
             microEpoch = Math.round(microEpoch * 1000) / 1000;
+
+            oldSetTime(microEpoch);
 
             // Microseconds are stored as integers
             this.microseconds = 1000 * (microEpoch - Math.floor(microEpoch));
@@ -395,11 +396,10 @@ API.txt for details.
         // reset smaller components
 
         if (step >= timeUnitSize.millisecond) {
-            if (step >= timeUnitSize.second) {
-                d.setMicroseconds(0);
-            } else {
-                d.setMicroseconds(d.getMilliseconds() * 1000);
-            }
+            d.setMicroseconds(0);
+        }
+        if (step >= timeUnitSize.second) {
+            d.setMilliseconds(0);
         }
         if (step >= timeUnitSize.minute) {
             d.setSeconds(0);

--- a/source/jquery.flot.time.js
+++ b/source/jquery.flot.time.js
@@ -31,7 +31,6 @@ API.txt for details.
 
         var oldSetTime = newDate.setTime.bind(newDate);
         newDate.update = function(microEpoch) {
-
             // Round epoch to 3 decimal accuracy
             microEpoch = Math.round(microEpoch * 1000) / 1000;
 

--- a/tests/jquery.flot.time.Test.js
+++ b/tests/jquery.flot.time.Test.js
@@ -56,6 +56,17 @@ describe('A Flot chart with absolute time axes', function () {
         ]);
     });
 
+    it('creates enough time ticks', function() {
+        plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0.95, 1], [1.95, 2]]], undefined, 'seconds');
+
+        var ticks = plot.getAxes().xaxis.ticks;
+        expect(ticks.length).toBeGreaterThan(10);
+        ticks.sort((a, b) => a.v - b.v);
+        for (var i = 1; i < ticks.length; i++) {
+            expect(ticks[i].v - ticks[i - 1].v).toBeLessThan(0.5);
+        }
+    });
+
     it('shows year time ticks', function () {
         plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[-373597200000, 1], [1199142000000, 2]]], '%Y', 'milliseconds');
 

--- a/tests/jquery.flot.time.Test.js
+++ b/tests/jquery.flot.time.Test.js
@@ -56,15 +56,15 @@ describe('A Flot chart with absolute time axes', function () {
         ]);
     });
 
-    it('creates enough time ticks', function() {
+    it('creates time ticks in expected locations', function() {
         plot = createPlotWithAbsoluteTimeAxis(placeholder, [[[0.95, 1], [1.95, 2]]], undefined, 'seconds');
 
         var ticks = plot.getAxes().xaxis.ticks;
-        expect(ticks.length).toBeGreaterThan(10);
-        ticks.sort((a, b) => a.v - b.v);
-        for (var i = 1; i < ticks.length; i++) {
-            expect(ticks[i].v - ticks[i - 1].v).toBeLessThan(0.5);
-        }
+        expect(ticks.length).toEqual(14);
+
+        // Check that the first generated tick is less than 1/4 of the way along the plot area width
+        var firstTickLocation = plot.getAxes().xaxis.p2c(ticks[1].v);
+        expect(firstTickLocation).toBeLessThan(plot.offset().left + (plot.width() / 4));
     });
 
     it('shows year time ticks', function () {

--- a/tests/jquery.flot.time.Test.js
+++ b/tests/jquery.flot.time.Test.js
@@ -107,6 +107,12 @@ describe('A Flot chart with absolute time axes', function () {
 
             expect(dateGenerator(123123, { timeBase: 'microseconds' }).getTime()).toEqual(123.123);
         });
+
+        it('rounds values to nearest microsecond timestamp', function() {
+            var dateGenerator = $.plot.dateGenerator;
+
+            expect(dateGenerator(999.9, { timeBase: 'microseconds' }).getTime()).toEqual(1);
+        });
     });
 
     describe('sub-second ticks', function () {


### PR DESCRIPTION
This PR addresses two already-reported issues when using micro epoch with the time axis

# 1. Missing ticks when using time axis

The code that resets the time of the first tick does not takes into account the seconds/millis/micro steps:
![image](https://user-images.githubusercontent.com/31401273/155120346-785bcffd-6c0d-4e10-b26b-bbb4daabf69d.png)

This PR adds the following sections to reset the micro and millis when needed:
```javascript
        if (step >= timeUnitSize.millisecond) {
            d.setMicroseconds(0);
        }
        if (step >= timeUnitSize.second) {
            d.setMilliseconds(0);
        }
```

The result after the fix:
![image](https://user-images.githubusercontent.com/31401273/155120515-497f10fe-be9e-4827-96b2-b8f00f7a47d9.png)


This also fixes another issue mentioned here:
https://github.com/flot/flot/issues/1743

# 2. Infinite loop in dateTickGenerator

Mentioned here:
https://github.com/flot/flot/issues/1792

In some cases, the date tick generator will run in an infinite loop due to a bug in the custom micro date implementation provided by Flot time plugin. 

In short: The micro epoch is rounded to 3 decimals AFTER setting the date using the default Date.setTime prototype, which means that when the micro epoch is of form 1645527365.999999999, setTime will receive 1645527365 instead of 1645527366. This caused an infinite loop within dateTickGenerator.

This PR fixes this issue by first rounding the micro epoch then calling the Date.setTime original prototype. 
