### PR TITLE
dynamically move colliding labels

### DIFF
--- a/source/jquery.flot.pie.js
+++ b/source/jquery.flot.pie.js
@@ -496,31 +496,50 @@ More detail and specific examples can be found in the included HTML file.
                         label.css("left", labelLeft);
 
                         // check to make sure that the label doesn't overlap one of the other labels
-                        var label_pos = getPositions(label);
-                        for(var j=0; j<labels.length; j++) {
-                            var tmpPos = getPositions(labels[j]);
-                            var horizontalMatch = comparePositions(label_pos[0], tmpPos[0]);
-                            var verticalMatch = comparePositions(label_pos[1], tmpPos[1]);
-                            var match = horizontalMatch && verticalMatch;
-                            if(match) {
-                                var newTop = tmpPos[1][0] - (label.height() + 1);
+                        let label_pos = getPositions(label);
+                        let bRepeat = false; // try moving label down if moving up doesn't work
+                        for(let j=0; j<labels.length; j++) {
+                            let tmpPos = getPositions(labels[j]);
+                            let horizontalMatch = comparePositions(label_pos[0], tmpPos[0]);
+                            let verticalMatch = comparePositions(label_pos[1], tmpPos[1]);
+                            if(horizontalMatch && verticalMatch) {
+                                // move up or down to try to avoid collision
+                                // (moving left or right doesn't generally work well)
+                                let newTop = tmpPos[1][0];
+                                if(bRepeat)
+                                    newTop -= label.height() + 1;
+                                else
+                                    newTop += label.height() + 1;
                                 label.css('top', newTop);
                                 labelTop = newTop;
+                                if(bRepeat > 3){
+                                    bRepeat = 0;
+                                }
+                                else{
+                                    j--; // retry this label to see if it conflicts now
+                                    bRepeat++;
+                                }
                             }
+                            label_pos = getPositions(label);
                         }
 
                         function getPositions(box) {
-                            var $box = $(box);
-                            var pos = $box.position();
-                            var width = $box.width();
-                            var height = $box.height();
-                            return [ [ pos.left, pos.left + width ], [ pos.top, pos.top + height ] ];
+                            let $box = $(box);
+                            let pos = $box.position();
+                            return [ [ pos.left, pos.left + $box.width() ], [ pos.top, pos.top + $box.height() ] ];
                         }
 
-                        function comparePositions(p1, p2) {
-                            var x1 = p1[0] < p2[0] ? p1 : p2;
-                            var x2 = p1[0] < p2[0] ? p2 : p1;
-                            return x1[1] > x2[0] || x1[0] === x2[0] ? true : false;
+                        // check for collision
+                        // Note this function is used for horizontal and vertical checks
+                        // so all comments of "left" could mean "top"
+                        function comparePositions(a, b) {
+                            // get left-most object
+                            let x1 = a[0] < b[0] ? a : b;
+                            // get the other object
+                            let x2 = a[0] < b[0] ? b : a;
+
+                            // return true if width of left-most object is right of the right-most object's position
+                            return x1[1] > x2[0];
                         }
                         labels.push(label);
 

--- a/source/jquery.flot.pie.js
+++ b/source/jquery.flot.pie.js
@@ -448,6 +448,7 @@ More detail and specific examples can be found in the included HTML file.
                 }
 
                 function drawLabels() {
+                    var labels = [];
                     var currentAngle = startAngle;
                     var radius = options.series.pie.label.radius > 1 ? options.series.pie.label.radius : maxRadius * options.series.pie.label.radius;
 
@@ -493,6 +494,35 @@ More detail and specific examples can be found in the included HTML file.
 
                         label.css("top", labelTop);
                         label.css("left", labelLeft);
+
+                        // check to make sure that the label doesn't overlap one of the other labels
+                        var label_pos = getPositions(label);
+                        for(var j=0; j<labels.length; j++) {
+                            var tmpPos = getPositions(labels[j]);
+                            var horizontalMatch = comparePositions(label_pos[0], tmpPos[0]);
+                            var verticalMatch = comparePositions(label_pos[1], tmpPos[1]);
+                            var match = horizontalMatch && verticalMatch;
+                            if(match) {
+                                var newTop = tmpPos[1][0] - (label.height() + 1);
+                                label.css('top', newTop);
+                                labelTop = newTop;
+                            }
+                        }
+
+                        function getPositions(box) {
+                            var $box = $(box);
+                            var pos = $box.position();
+                            var width = $box.width();
+                            var height = $box.height();
+                            return [ [ pos.left, pos.left + width ], [ pos.top, pos.top + height ] ];
+                        }
+
+                        function comparePositions(p1, p2) {
+                            var x1 = p1[0] < p2[0] ? p1 : p2;
+                            var x2 = p1[0] < p2[0] ? p2 : p1;
+                            return x1[1] > x2[0] || x1[0] === x2[0] ? true : false;
+                        }
+                        labels.push(label);
 
                         // check to make sure that the label is not outside the canvas
                         if (0 - labelTop > 0 || 0 - labelLeft > 0 || canvasHeight - (labelTop + label.height()) < 0 || canvasWidth - (labelLeft + label.width()) < 0) {


### PR DESCRIPTION
Reformatted https://stackoverflow.com/questions/9496689/overlapping-labels-in-flot-pie-chart (there is an existing pull request, but it had a bunch of space changes so hard to see what was actually changed).

I also "upgraded" the SO code by adding in a repeat to try multiple times to move the elements around, by moving up *and* down.

There was a bug in the code in that it didn't update the label_pos so created more collisions than it needed to.